### PR TITLE
[Feat] 로그인 API 구현

### DIFF
--- a/src/main/java/com/phu/backend/config/jwt/JWTFilter.java
+++ b/src/main/java/com/phu/backend/config/jwt/JWTFilter.java
@@ -1,0 +1,68 @@
+package com.phu.backend.config.jwt;
+
+import com.phu.backend.dto.auth.MemberDetails;
+import com.phu.backend.exception.jwt.AccessTokenExpiredException;
+import com.phu.backend.exception.jwt.TokenNotValidateException;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Slf4j
+public class JWTFilter extends OncePerRequestFilter {
+    private final JWTUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        // request 에서 Authorization 헤더 조회
+        String authorization = request.getHeader("Authorization");
+
+        // 권한이 필요없는 요청일경우 해당 필터 생략
+        if (authorization == null || !authorization.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+
+            return;
+        }
+
+        // 순수 토큰 추출
+        String accessToken = authorization.split(" ")[1];
+
+
+        // 토큰 검증
+        try {
+            jwtUtil.isExpired(accessToken);
+        }catch (ExpiredJwtException e) {
+            throw new AccessTokenExpiredException();
+        }catch (Exception e) {
+            throw new TokenNotValidateException();
+        }
+
+        String category = jwtUtil.getCategory(accessToken);
+
+        if (!category.equals("access")) {
+            throw new TokenNotValidateException();
+        }
+
+        String username = jwtUtil.getUsername(accessToken);
+        String role = jwtUtil.getRole(accessToken);
+
+
+        MemberDetails memberDetails = new MemberDetails(username, "temppassword", role);
+
+        UsernamePasswordAuthenticationToken authToken
+                = new UsernamePasswordAuthenticationToken(memberDetails, null, memberDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/phu/backend/config/jwt/JWTUtil.java
+++ b/src/main/java/com/phu/backend/config/jwt/JWTUtil.java
@@ -1,0 +1,62 @@
+package com.phu.backend.config.jwt;
+
+import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JWTUtil {
+
+    private final SecretKey secretKey;
+    private final int accessTokenExpirationMinutes;
+    private final int refreshTokenExpirationMinutes;
+
+    public JWTUtil(@Value("${jwt.secret}") String secret,
+                   @Value("${jwt.access-token-expiration-minutes}") int accessTokenExpirationMinutes,
+                   @Value("${jwt.refresh-token-expiration-minutes}") int refreshTokenExpirationMinutes) {
+
+        this.secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+        this.accessTokenExpirationMinutes = accessTokenExpirationMinutes;
+        this.refreshTokenExpirationMinutes = refreshTokenExpirationMinutes;
+    }
+
+    public String getUsername(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("username", String.class);
+    }
+
+    public String getRole(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
+    }
+
+    public String getCategory(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("category", String.class);
+    }
+
+    public Boolean isExpired(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+    }
+
+    public String createJwt(String category, String username, String role) {
+        int expiredMs = 0;
+        if (category.equals("access")) {
+            expiredMs = this.accessTokenExpirationMinutes;
+        }
+        if (category.equals("refresh")) {
+            expiredMs = this.refreshTokenExpirationMinutes;
+        }
+
+        return Jwts.builder()
+                .claim("category", category)
+                .claim("username", username)
+                .claim("role", role)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expiredMs))
+                .signWith(secretKey)
+                .compact();
+    }
+}

--- a/src/main/java/com/phu/backend/config/jwt/JwtExceptionFilter.java
+++ b/src/main/java/com/phu/backend/config/jwt/JwtExceptionFilter.java
@@ -1,0 +1,40 @@
+package com.phu.backend.config.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.phu.backend.exception.GlobalException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class JwtExceptionFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (GlobalException ex) {
+            sendErrorResponse(response, ex);
+        }
+    }
+
+    public void sendErrorResponse(HttpServletResponse response, GlobalException exception) throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("code", exception.getStatusCode());
+        body.put("message", exception.getMessage());
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.writeValue(response.getOutputStream(), body);
+    }
+}

--- a/src/main/java/com/phu/backend/config/jwt/LoginFilter.java
+++ b/src/main/java/com/phu/backend/config/jwt/LoginFilter.java
@@ -1,0 +1,94 @@
+package com.phu.backend.config.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.phu.backend.domain.jwt.RefreshToken;
+import com.phu.backend.dto.auth.MemberDetails;
+import com.phu.backend.dto.member.request.LoginRequest;
+import com.phu.backend.exception.member.EmailOrPasswordNotExistException;
+import com.phu.backend.repository.jwt.RefreshTokenRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+
+@RequiredArgsConstructor
+@Slf4j
+public class LoginFilter extends UsernamePasswordAuthenticationFilter {
+    private final AuthenticationManager authenticationManager;
+    private final JWTUtil jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Override
+    @SneakyThrows
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        LoginRequest memberLoginRequest = objectMapper.readValue(request.getInputStream(), LoginRequest.class);
+
+        String username = memberLoginRequest.getEmail();
+        String password = memberLoginRequest.getPassword();
+
+        UsernamePasswordAuthenticationToken authToken
+                = new UsernamePasswordAuthenticationToken(username, password, null);
+
+        return authenticationManager.authenticate(authToken);
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) throws IOException, ServletException {
+        MemberDetails memberDetails = (MemberDetails) authentication.getPrincipal();
+
+        // Email 추출
+        String username = memberDetails.getUsername();
+
+        // 권한 추출
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        GrantedAuthority auth = iterator.next();
+
+        String role = auth.getAuthority();
+
+        String access = jwtUtil.createJwt("access", username, role);
+        String refresh = jwtUtil.createJwt("refresh", username, role);
+
+        RefreshToken refreshTokenForRedis = RefreshToken.builder()
+                .refreshToken(refresh)
+                .email(username)
+                .build();
+
+        refreshTokenRepository.save(refreshTokenForRedis);
+
+        response.setHeader("Authorization", "Bearer " + access);
+        response.addCookie(createCookie("refresh", refresh));
+        response.setStatus(HttpStatus.OK.value());
+    }
+
+    private Cookie createCookie(String key, String value) {
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(24 * 60 * 60);
+//        cookie.setSecure(true); HTTPS 통신시 주석 해제
+//        cookie.setPath("/"); 쿠키가 적용 될 범위 설정 필요시 사용
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws ServletException {;
+        throw new EmailOrPasswordNotExistException();
+    }
+}

--- a/src/main/java/com/phu/backend/config/redis/RedisInitializationService.java
+++ b/src/main/java/com/phu/backend/config/redis/RedisInitializationService.java
@@ -1,0 +1,25 @@
+package com.phu.backend.config.redis;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RedisInitializationService {
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @PostConstruct
+    public void clearRedisCache() {
+        try {
+            log.info("Initializing Redis: Clearing all data");
+            redisTemplate.getConnectionFactory().getConnection().flushAll();
+            log.info("Redis data cleared successfully");
+        } catch (Exception e) {
+            log.error("Error occurred while clearing Redis data", e);
+        }
+    }
+}

--- a/src/main/java/com/phu/backend/controller/auth/AuthController.java
+++ b/src/main/java/com/phu/backend/controller/auth/AuthController.java
@@ -1,0 +1,28 @@
+package com.phu.backend.controller.auth;
+
+import com.phu.backend.service.auth.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "인증 관련 API", description = "JWT 기반의 인증을 관리하는 API")
+public class AuthController {
+    private final AuthService authService;
+    @PostMapping("/reissue")
+    @Operation(summary = "리프레시 토큰 발급", description = "클라이언트 쿠키에 있는 리프레시 토큰을 검증해 새로운 엑세스토큰을 재발급하는 API")
+    public ResponseEntity<Void> reissue(HttpServletRequest request, HttpServletResponse response) {
+        return ResponseEntity.ok()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + authService.reissue(request, response))
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/phu/backend/domain/jwt/RefreshToken.java
+++ b/src/main/java/com/phu/backend/domain/jwt/RefreshToken.java
@@ -1,0 +1,19 @@
+package com.phu.backend.domain.jwt;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@RedisHash(value = "refreshToken", timeToLive = 1000000)
+public class RefreshToken {
+    @Id
+    private String refreshToken;
+    private String email;
+    @Builder
+    public RefreshToken(String refreshToken, String email) {
+        this.refreshToken = refreshToken;
+        this.email = email;
+    }
+}

--- a/src/main/java/com/phu/backend/domain/member/Member.java
+++ b/src/main/java/com/phu/backend/domain/member/Member.java
@@ -18,6 +18,7 @@ public class Member extends BaseTimeEntity {
     @Column(name = "user_id")
     private Long id;
     @Email
+    @Column(unique = true)
     private String email;
     private String password;
     private String name;

--- a/src/main/java/com/phu/backend/dto/auth/MemberDetails.java
+++ b/src/main/java/com/phu/backend/dto/auth/MemberDetails.java
@@ -1,0 +1,61 @@
+package com.phu.backend.dto.auth;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@Getter
+@RequiredArgsConstructor
+public class MemberDetails implements UserDetails {
+    private final String email;
+    private final String password;
+    private final String role;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+
+        collection.add(new GrantedAuthority() {
+            @Override
+            public String getAuthority() {
+                return role;
+            }
+        });
+
+        return collection;
+    }
+
+    @Override
+    public String getPassword() {
+        return this.password;
+    }
+
+    @Override
+    public String getUsername() {
+        return this.email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/phu/backend/dto/member/request/LoginRequest.java
+++ b/src/main/java/com/phu/backend/dto/member/request/LoginRequest.java
@@ -1,0 +1,16 @@
+package com.phu.backend.dto.member.request;
+
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class LoginRequest {
+    @Email(message = "이메일 형식이 아닙니다")
+    @NotBlank(message = "이메일을 입력하세요")
+    private String email;
+
+    @NotBlank(message = "비밀번호를 입력하세요")
+    private String password;
+}

--- a/src/main/java/com/phu/backend/dto/member/request/SingInRequest.java
+++ b/src/main/java/com/phu/backend/dto/member/request/SingInRequest.java
@@ -25,10 +25,12 @@ public class SingInRequest {
     @Schema(description = "사용자 나이", nullable = false, example = "27")
     private Integer age;
     @Schema(description = "사용자 성별", nullable = false, example = "MALE")
+    @NotNull
     private Gender gender;
     @NotBlank(message = "전화번호를 입력하세요")
     @Schema(description = "사용자 전화번호", nullable = false, example = "01046666208")
     private String tel;
     @Schema(description = "사용자 분류", nullable = false, example = "TRAINER")
+    @NotNull
     private Part part;
 }

--- a/src/main/java/com/phu/backend/exception/jwt/AccessTokenExpiredException.java
+++ b/src/main/java/com/phu/backend/exception/jwt/AccessTokenExpiredException.java
@@ -1,0 +1,15 @@
+package com.phu.backend.exception.jwt;
+
+import com.phu.backend.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class AccessTokenExpiredException extends GlobalException {
+    public static final String MESSAGE = "만료된 엑세스 토큰입니다.";
+    @Override
+    public String getStatusCode() {
+        return "J001";
+    }
+    public AccessTokenExpiredException() {
+        super(MESSAGE, HttpStatus.NOT_ACCEPTABLE);
+    }
+}

--- a/src/main/java/com/phu/backend/exception/jwt/RefreshTokenExpiredException.java
+++ b/src/main/java/com/phu/backend/exception/jwt/RefreshTokenExpiredException.java
@@ -1,0 +1,15 @@
+package com.phu.backend.exception.jwt;
+
+import com.phu.backend.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class RefreshTokenExpiredException extends GlobalException {
+    public static final String MESSAGE = "만료된 리프레시 토큰입니다.";
+    @Override
+    public String getStatusCode() {
+        return "J002";
+    }
+    public RefreshTokenExpiredException() {
+        super(MESSAGE, HttpStatus.NOT_ACCEPTABLE);
+    }
+}

--- a/src/main/java/com/phu/backend/exception/jwt/RefreshTokenNotExistException.java
+++ b/src/main/java/com/phu/backend/exception/jwt/RefreshTokenNotExistException.java
@@ -1,0 +1,15 @@
+package com.phu.backend.exception.jwt;
+
+import com.phu.backend.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class RefreshTokenNotExistException extends GlobalException {
+    public static final String MESSAGE = "리프레시 토큰 조회에 실패했습니다";
+    @Override
+    public String getStatusCode() {
+        return "J003";
+    }
+    public RefreshTokenNotExistException() {
+        super(MESSAGE, HttpStatus.NOT_ACCEPTABLE);
+    }
+}

--- a/src/main/java/com/phu/backend/exception/jwt/TokenNotValidateException.java
+++ b/src/main/java/com/phu/backend/exception/jwt/TokenNotValidateException.java
@@ -1,0 +1,15 @@
+package com.phu.backend.exception.jwt;
+
+import com.phu.backend.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class TokenNotValidateException extends GlobalException {
+    public static final String MESSAGE = "잘못된 JWT 토큰입니다.";
+    @Override
+    public String getStatusCode() {
+        return "J004";
+    }
+    public TokenNotValidateException() {
+        super(MESSAGE, HttpStatus.NOT_ACCEPTABLE);
+    }
+}

--- a/src/main/java/com/phu/backend/exception/member/EmailOrPasswordNotExistException.java
+++ b/src/main/java/com/phu/backend/exception/member/EmailOrPasswordNotExistException.java
@@ -1,0 +1,15 @@
+package com.phu.backend.exception.member;
+
+import com.phu.backend.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class EmailOrPasswordNotExistException extends GlobalException {
+    public static final String MESSAGE = "데이터베이스 내부에 존재하지 않는 이메일 혹은 비밀번호입니다.";
+    @Override
+    public String getStatusCode() {
+        return "M002";
+    }
+    public EmailOrPasswordNotExistException() {
+        super(MESSAGE, HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/phu/backend/repository/jwt/RefreshTokenRepository.java
+++ b/src/main/java/com/phu/backend/repository/jwt/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package com.phu.backend.repository.jwt;
+
+import com.phu.backend.domain.jwt.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+}

--- a/src/main/java/com/phu/backend/repository/member/MemberRepository.java
+++ b/src/main/java/com/phu/backend/repository/member/MemberRepository.java
@@ -3,6 +3,9 @@ package com.phu.backend.repository.member;
 import com.phu.backend.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmail(String email);
     boolean existsByEmail(String email);
 }

--- a/src/main/java/com/phu/backend/service/auth/AuthService.java
+++ b/src/main/java/com/phu/backend/service/auth/AuthService.java
@@ -1,0 +1,79 @@
+package com.phu.backend.service.auth;
+
+import com.phu.backend.config.jwt.JWTUtil;
+import com.phu.backend.domain.jwt.RefreshToken;
+import com.phu.backend.exception.jwt.RefreshTokenExpiredException;
+import com.phu.backend.exception.jwt.RefreshTokenNotExistException;
+import com.phu.backend.exception.jwt.TokenNotValidateException;
+import com.phu.backend.repository.jwt.RefreshTokenRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final JWTUtil jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
+    public String reissue(HttpServletRequest request, HttpServletResponse response) {
+        String refresh = null;
+        Cookie[] cookies = request.getCookies();
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals("refresh")) {
+                refresh = cookie.getValue();
+            }
+        }
+
+        if (refresh == null) {
+            throw new RefreshTokenNotExistException();
+        }
+
+        // 만료여부 검사
+        try {
+            jwtUtil.isExpired(refresh);
+        } catch (ExpiredJwtException e) {
+            throw new RefreshTokenExpiredException();
+        }
+
+        String category = jwtUtil.getCategory(refresh);
+        if (!category.equals("refresh")) {
+            throw new TokenNotValidateException();
+        }
+
+        // Redis 내부에 토큰이 있는지 검증
+        RefreshToken redisToken = refreshTokenRepository.findById(refresh)
+                .orElseThrow(RefreshTokenNotExistException::new);
+
+        String username = jwtUtil.getUsername(refresh);
+        String role = jwtUtil.getRole(refresh);
+
+        // 재할당
+        String accessToken = jwtUtil.createJwt("access", username, role);
+        String refreshToken = jwtUtil.createJwt("refresh", username, role);
+
+        RefreshToken newRefreshToken = RefreshToken.builder()
+                .email(username)
+                .refreshToken(refreshToken)
+                .build();
+
+        refreshTokenRepository.delete(redisToken);
+        refreshTokenRepository.save(newRefreshToken);
+
+        response.addCookie(createCookie("refresh", refreshToken));
+
+        return accessToken;
+    }
+
+    private Cookie createCookie(String key, String value) {
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(24 * 60 * 60);
+//        cookie.setSecure(true); HTTPS 통신시 주석 해제
+//        cookie.setPath("/"); 쿠키가 적용 될 범위 설정 필요시 사용
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+}

--- a/src/main/java/com/phu/backend/service/auth/MemberDetailsService.java
+++ b/src/main/java/com/phu/backend/service/auth/MemberDetailsService.java
@@ -1,0 +1,24 @@
+package com.phu.backend.service.auth;
+
+import com.phu.backend.domain.member.Member;
+import com.phu.backend.dto.auth.MemberDetails;
+import com.phu.backend.exception.member.EmailOrPasswordNotExistException;
+import com.phu.backend.repository.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Member member = memberRepository.findByEmail(username).orElseThrow(EmailOrPasswordNotExistException::new);
+
+        return new MemberDetails(member.getEmail(),member.getPassword(),member.getRole());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,9 +34,9 @@ spring:
         enabled: true
 
 jwt:
-  header: Authorization
   secret: ${JWT_SECRET}
-  token-validity-in-seconds: 86400
+  access-token-expiration-minutes: 600000
+  refresh-token-expiration-minutes: 6000000
 
 server:
   port: 443


### PR DESCRIPTION
# 로그인
<br>

## API 명세
<img width="822" alt="스크린샷 2024-09-23 오후 5 37 33" src="https://github.com/user-attachments/assets/0dfb46c5-6d41-4037-8669-5850df1e3258">

<br>
## 로그인 성공시 응답값

상태코드 200
**헤더에 엑세스 토큰 발급**
<img width="803" alt="스크린샷 2024-09-23 오후 5 38 30" src="https://github.com/user-attachments/assets/4b7573ef-f251-4796-8fe4-59fe93994f93">

**쿠키에 리프레시 토큰 발급**
<img width="827" alt="스크린샷 2024-09-23 오후 5 38 56" src="https://github.com/user-attachments/assets/1195d271-47bd-4793-8446-3016d6a97b47">

엑세스 토큰 만료시간 : 10분
리프레시 토큰 만료시간 : 100분

<br>

엑세스토큰 만료시 재발급하는 API
<img width="815" alt="스크린샷 2024-09-23 오후 5 39 36" src="https://github.com/user-attachments/assets/3dc87811-e19c-4eca-b259-6121ecd8b1ae">

기존 리프레시 토큰 검증 후 삭제 및 쿠키에 새로운 리프레시 토큰값 설정 + 새로운 엑세스토큰 헤더에 저장
리프레시 토큰은 ReidsHash로 TTL 관리
<br>

로그인 실패 시
<img width="833" alt="스크린샷 2024-09-23 오후 5 42 14" src="https://github.com/user-attachments/assets/743a7767-0158-4866-9a5a-043d7c72da4e">

close #9 