### PR TITLE
[Feat] 소셜로그인 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
 
     // Validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // OAuth2
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/phu/backend/config/oauth/CustomOAuth2User.java
+++ b/src/main/java/com/phu/backend/config/oauth/CustomOAuth2User.java
@@ -1,0 +1,46 @@
+package com.phu.backend.config.oauth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class CustomOAuth2User implements OAuth2User {
+    private final OAuthRequest oAuthRequest;
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return null;
+    }
+
+    @Override
+    public Map<String, Object> getAttribute(String name) {
+        return null;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+        collection.add(new GrantedAuthority() {
+            @Override
+            public String getAuthority() {
+                return oAuthRequest.getRole();
+            }
+        });
+
+        return collection;
+    }
+
+    @Override
+    public String getName() {
+        return oAuthRequest.getName();
+    }
+
+    public String getUsername() {
+        return oAuthRequest.getUsername();
+    }
+}

--- a/src/main/java/com/phu/backend/config/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/phu/backend/config/oauth/CustomOAuth2UserService.java
@@ -1,0 +1,76 @@
+package com.phu.backend.config.oauth;
+
+import com.phu.backend.domain.member.Member;
+import com.phu.backend.repository.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+    private final MemberRepository memberRepository;
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        log.info("oAuth2User:{}", oAuth2User);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        OAuth2Response oAuth2Response = null;
+
+        // TODO 추후 다른 소셜로그인 도입시 추가 로직 구성 현재는 구글만
+        if (registrationId.equals("google")) {
+            oAuth2Response = new GoogleResponse(oAuth2User.getAttributes());
+        } else {
+            return null;
+        }
+
+        String socialId = oAuth2Response.getProvider() + oAuth2Response.getProviderId();
+
+        // 소셜로그인으로 등록한 기록이 있는지
+        Member existData = memberRepository.findBySocialId(socialId);
+
+        if (existData == null || existData.getRole().equals("ROLE_BEFORE_USER")) {
+
+            if (existData == null) {
+                Member member = Member.builder()
+                        .email(oAuth2Response.getEmail())
+                        .name(oAuth2Response.getName())
+                        .role("ROLE_BEFORE_USER")
+                        .build();
+
+                member.confirmSocialId(socialId);
+
+                memberRepository.save(member);
+            }
+
+            // 추가 회원가입을 안한 회원인가
+            OAuthRequest oAuthRequest = OAuthRequest.builder()
+                    .username(socialId)
+                    .name(oAuth2Response.getName())
+                    .role("ROLE_BEFORE_USER")
+                    .build();
+
+
+            return new CustomOAuth2User(oAuthRequest);
+        } else {
+            existData.changeMemberInfo(oAuth2Response.getEmail(), oAuth2Response.getName());
+            memberRepository.save(existData);
+
+            OAuthRequest oAuthRequest = OAuthRequest.builder()
+                    .username(socialId)
+                    .name(oAuth2Response.getName())
+                    .role("ROLE_USER")
+                    .build();
+            return new CustomOAuth2User(oAuthRequest);
+        }
+    }
+}

--- a/src/main/java/com/phu/backend/config/oauth/GoogleResponse.java
+++ b/src/main/java/com/phu/backend/config/oauth/GoogleResponse.java
@@ -1,0 +1,30 @@
+package com.phu.backend.config.oauth;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class GoogleResponse implements OAuth2Response {
+    private final Map<String, Object> attribute;
+
+    @Override
+    public String getProvider() {
+        return "google";
+    }
+
+    @Override
+    public String getProviderId() {
+        return attribute.get("sub").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return attribute.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+        return attribute.get("name").toString();
+    }
+}

--- a/src/main/java/com/phu/backend/config/oauth/OAuth2Response.java
+++ b/src/main/java/com/phu/backend/config/oauth/OAuth2Response.java
@@ -1,0 +1,11 @@
+package com.phu.backend.config.oauth;
+
+public interface OAuth2Response {
+    // 소셜 제공자
+    String getProvider();
+    String getProviderId();
+    // 이메일
+    String getEmail();
+    // 실명
+    String getName();
+}

--- a/src/main/java/com/phu/backend/config/oauth/OAuthRequest.java
+++ b/src/main/java/com/phu/backend/config/oauth/OAuthRequest.java
@@ -1,0 +1,18 @@
+package com.phu.backend.config.oauth;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class OAuthRequest {
+    private String role;
+    private String username;
+    private String name;
+
+    @Builder
+    public OAuthRequest(String role, String username, String name) {
+        this.role = role;
+        this.username = username;
+        this.name = name;
+    }
+}

--- a/src/main/java/com/phu/backend/config/oauth/OAuthSuccessHandler.java
+++ b/src/main/java/com/phu/backend/config/oauth/OAuthSuccessHandler.java
@@ -1,0 +1,83 @@
+package com.phu.backend.config.oauth;
+
+import com.phu.backend.config.jwt.JWTUtil;
+import com.phu.backend.domain.jwt.RefreshToken;
+import com.phu.backend.repository.jwt.RefreshTokenRepository;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+    private final JWTUtil jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+
+        //OAuth2User
+        CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
+
+        String username = customUserDetails.getUsername();
+
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        GrantedAuthority auth = iterator.next();
+        String role = auth.getAuthority();
+
+        log.info("username:{}", username);
+        // 추가 회원가입
+        if (role.equals("ROLE_BEFORE_USER")) {
+            response.addCookie(createSocialCookie("social_id", username));
+            response.sendRedirect("http://localhost:5173/social/sign-up");
+        }
+        // 소셜 로그인 진행 및 jwt 발급
+        if (role.equals("ROLE_USER")) {
+            String access = jwtUtil.createJwt("access", username, role);
+            String refresh = jwtUtil.createJwt("refresh", username, role);
+
+            RefreshToken refreshTokenForRedis = RefreshToken.builder()
+                    .refreshToken(refresh)
+                    .email(username)
+                    .build();
+
+            refreshTokenRepository.save(refreshTokenForRedis);
+
+            response.addCookie(createRefreshCookie("refresh", refresh));
+            response.setHeader("Authorization", "Bearer " + access);
+            response.sendRedirect("http://localhost:5173/");
+        }
+    }
+
+    private Cookie createRefreshCookie(String key, String value) {
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(24 * 60 * 60);
+        cookie.setSecure(true);
+//        cookie.setPath("/"); 쿠키가 적용 될 범위 설정 필요시 사용
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+
+    private Cookie createSocialCookie(String key, String value) {
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(30 * 60);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+}

--- a/src/main/java/com/phu/backend/config/security/WebConfig.java
+++ b/src/main/java/com/phu/backend/config/security/WebConfig.java
@@ -6,10 +6,9 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
-
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:3000");
+                .allowedOrigins("http://localhost:5173");
     }
 }

--- a/src/main/java/com/phu/backend/controller/member/MemberController.java
+++ b/src/main/java/com/phu/backend/controller/member/MemberController.java
@@ -1,9 +1,11 @@
 package com.phu.backend.controller.member;
 
-import com.phu.backend.dto.member.request.SingInRequest;
+import com.phu.backend.dto.member.request.SignUpRequest;
+import com.phu.backend.dto.member.request.SignUpSocial;
 import com.phu.backend.service.member.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,9 +19,15 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    @PostMapping("/sign-in")
-    @Operation(summary = "회원가입", description = "사용자가 회원가입을 한다")
-    public void signIn(@RequestBody @Valid SingInRequest request) {
-        memberService.signIn(request);
+    @PostMapping("/sign-up")
+    @Operation(summary = "회원가입", description = "사용자가 기본 회원가입을 한다")
+    public void signUp(@RequestBody @Valid SignUpRequest request) {
+        memberService.signUp(request);
+    }
+
+    @PostMapping("/sign-up/social")
+    @Operation(summary = "소셜 회원가입", description = "사용자가 소셜 로그인 회원가입을 한다")
+    public void signUp(@RequestBody @Valid SignUpSocial request, HttpServletRequest servletRequest) {
+        memberService.signUpSocial(request, servletRequest);
     }
 }

--- a/src/main/java/com/phu/backend/domain/member/Member.java
+++ b/src/main/java/com/phu/backend/domain/member/Member.java
@@ -29,12 +29,31 @@ public class Member extends BaseTimeEntity {
     @Enumerated(value = EnumType.STRING)
     private Part part;
     private String role;
+    private String socialId;
 
     @Builder
     public Member(String email, String password, String name, Integer age, Gender gender, String tel, Part part, String role) {
         this.email = email;
         this.password = password;
         this.name = name;
+        this.age = age;
+        this.gender = gender;
+        this.tel = tel;
+        this.part = part;
+        this.role = role;
+    }
+
+    public void confirmSocialId(String socialId) {
+        this.socialId = socialId;
+    }
+
+    public void changeMemberInfo(String email, String name) {
+        this.email = email;
+        this.name = name;
+    }
+
+    public void signUpForSocial(String password, Integer age, Gender gender, String tel, Part part, String role) {
+        this.password = password;
         this.age = age;
         this.gender = gender;
         this.tel = tel;

--- a/src/main/java/com/phu/backend/dto/member/request/SignUpRequest.java
+++ b/src/main/java/com/phu/backend/dto/member/request/SignUpRequest.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 
 @Getter
 @Schema(description = "회원이 회원가입할때 필요한 데이터")
-public class SingInRequest {
+public class SignUpRequest {
     @NotBlank(message = "이메일을 입력하세요")
     @Email(message = "이메일 형식이 아닙니다")
     @Schema(description = "사용자 이메일", nullable = false, example = "mr6208@naver.com")

--- a/src/main/java/com/phu/backend/dto/member/request/SignUpSocial.java
+++ b/src/main/java/com/phu/backend/dto/member/request/SignUpSocial.java
@@ -1,0 +1,28 @@
+package com.phu.backend.dto.member.request;
+
+import com.phu.backend.domain.member.Gender;
+import com.phu.backend.domain.member.Part;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "회원이 소셜로그인 회원가입시 필요한 추가적인 데이터")
+public class SignUpSocial {
+    @NotBlank(message = "비밀번호를 입력하세요")
+    @Schema(description = "사용자 비밀번호", nullable = false, example = "asdf1020")
+    private String password;
+    @NotNull(message = "나이를 입력하세요")
+    @Schema(description = "사용자 나이", nullable = false, example = "27")
+    private Integer age;
+    @Schema(description = "사용자 성별", nullable = false, example = "MALE")
+    @NotNull
+    private Gender gender;
+    @NotBlank(message = "전화번호를 입력하세요")
+    @Schema(description = "사용자 전화번호", nullable = false, example = "01046666208")
+    private String tel;
+    @Schema(description = "사용자 분류", nullable = false, example = "TRAINER")
+    @NotNull
+    private Part part;
+}

--- a/src/main/java/com/phu/backend/exception/oauth/NotFoundSocialIdException.java
+++ b/src/main/java/com/phu/backend/exception/oauth/NotFoundSocialIdException.java
@@ -1,0 +1,15 @@
+package com.phu.backend.exception.oauth;
+
+import com.phu.backend.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class NotFoundSocialIdException extends GlobalException {
+    public static final String MESSAGE = "소셜아이디를 찾지 못했습니다.";
+    @Override
+    public String getStatusCode() {
+        return "SO001";
+    }
+    public NotFoundSocialIdException() {
+        super(MESSAGE, HttpStatus.NOT_ACCEPTABLE);
+    }
+}

--- a/src/main/java/com/phu/backend/repository/member/MemberRepository.java
+++ b/src/main/java/com/phu/backend/repository/member/MemberRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
     boolean existsByEmail(String email);
+    Member findBySocialId(String id);
 }

--- a/src/main/java/com/phu/backend/service/member/MemberService.java
+++ b/src/main/java/com/phu/backend/service/member/MemberService.java
@@ -1,9 +1,13 @@
 package com.phu.backend.service.member;
 
 import com.phu.backend.domain.member.Member;
-import com.phu.backend.dto.member.request.SingInRequest;
+import com.phu.backend.dto.member.request.SignUpRequest;
+import com.phu.backend.dto.member.request.SignUpSocial;
 import com.phu.backend.exception.member.DuplicationEmailException;
+import com.phu.backend.exception.oauth.NotFoundSocialIdException;
 import com.phu.backend.repository.member.MemberRepository;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -16,7 +20,7 @@ public class MemberService {
     private final BCryptPasswordEncoder passwordEncoder;
 
     @Transactional
-    public void signIn(SingInRequest request) {
+    public void signUp(SignUpRequest request) {
         if (memberRepository.existsByEmail(request.getEmail())) {
             throw new DuplicationEmailException();
         }
@@ -33,5 +37,24 @@ public class MemberService {
                 .build();
 
         memberRepository.save(member);
+    }
+
+    @Transactional
+    public void signUpSocial(SignUpSocial request, HttpServletRequest servletRequest) {
+        String socialId = null;
+        Cookie[] cookies = servletRequest.getCookies();
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals("social_id")) {
+                socialId = cookie.getValue();
+            }
+        }
+        if (socialId == null) {
+            throw new NotFoundSocialIdException();
+        }
+
+        Member member = memberRepository.findBySocialId(socialId);
+        String password = passwordEncoder.encode(request.getPassword());
+
+        member.signUpForSocial(password, request.getAge(), request.getGender(), request.getTel(), request.getPart(), "ROLE_USER");
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,42 @@
+spring:
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+
+  data:
+    web:
+      pageable:
+        one-indexed-parameters: true
+        default-page-size: 5
+
+    redis:
+      host: localhost
+      port: 6379
+
+  datasource:
+    url: jdbc:h2:mem:mr6208;MODE=MYSQL
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-secret: ${CLIENT_SECRET}
+            client-id: ${CLIENT_ID}
+            scope:
+              - email
+              - profile
+
+jwt:
+  secret: asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdf12
+  access-token-expiration-minutes: 1
+  refresh-token-expiration-minutes: 6000000
+

--- a/src/main/resources/application-oauth.yml
+++ b/src/main/resources/application-oauth.yml
@@ -1,0 +1,11 @@
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-secret: ${CLIENT_SECRET}
+            client-id: ${CLIENT_ID}
+            scope:
+              - email
+              - profile

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  profiles:
+    include: oauth
+
   main:
     allow-bean-definition-overriding: true
 
@@ -23,9 +26,6 @@ spring:
     password: ${MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
-#    sql:
-#      init:
-#        mode: always
   data:
     redis:
       host: redis


### PR DESCRIPTION
# 로그인 요청 주소
{도메인명}/oauth2/authorization/google


<img width="1241" alt="스크린샷 2024-10-01 오후 7 28 25" src="https://github.com/user-attachments/assets/65add01b-41dd-4535-aa44-94f91507f2d8">

# 해당 서비스에 첫번째 로그인 (소셜로그인이 처음일시에 해당 url로 리디렉션)
<img width="1250" alt="스크린샷 2024-10-01 오후 7 31 07" src="https://github.com/user-attachments/assets/8e8a393d-49b7-42a5-bc1f-6a67a63a7a0b">
<br>
# 데이터베이스에 소셜로그인시 받아온 정보 세팅 및 role, 소셜 아이디 필드 세팅
<img width="1173" alt="스크린샷 2024-10-01 오후 7 32 28" src="https://github.com/user-attachments/assets/a88abd7c-2b46-431b-93fa-4b73404bbd27">

# 해당 페이지에서 사용자는 추가적인 회원가입API 을 통해 서비스에 등록한다
<img width="1447" alt="스크린샷 2024-10-01 오후 7 31 50" src="https://github.com/user-attachments/assets/1ae3f61b-8ca4-4714-8717-57b1ebdcede6">

# 추가 회원가입 완료시 변경된 회원 정보
<img width="1244" alt="스크린샷 2024-10-01 오후 7 33 39" src="https://github.com/user-attachments/assets/89e1e2ac-756d-4324-b1d4-e95fc4ae3085">

# 해당 아이디로 소셜로그인 후에는 해당 url로 리디렉션한다.
<img width="1302" alt="스크린샷 2024-10-01 오후 7 34 09" src="https://github.com/user-attachments/assets/75449881-ab96-4c62-9002-2403d4160d05">


close #13 


