### PR TITLE
[Refactor] 소셜 회원가입 리팩토링

### DIFF
--- a/src/main/java/com/phu/backend/config/SecurityConfig.java
+++ b/src/main/java/com/phu/backend/config/SecurityConfig.java
@@ -12,6 +12,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -66,11 +67,11 @@ public class SecurityConfig {
                         CorsConfiguration configuration = new CorsConfiguration();
 
                         configuration.setAllowedOrigins(List.of(LOCALHOST, WEB));
-                        configuration.setAllowedMethods(Collections.singletonList("*"));
+                        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"));
                         configuration.setAllowCredentials(true);
                         configuration.setAllowedHeaders(Collections.singletonList("*"));
                         configuration.setMaxAge(3600L);
-                        configuration.setExposedHeaders(Collections.singletonList("Authorization"));
+                        configuration.setExposedHeaders(List.of(HttpHeaders.SET_COOKIE, HttpHeaders.AUTHORIZATION));
 
                         return configuration;
                     }

--- a/src/main/java/com/phu/backend/controller/member/MemberController.java
+++ b/src/main/java/com/phu/backend/controller/member/MemberController.java
@@ -8,7 +8,6 @@ import com.phu.backend.dto.member.response.MemberResponse;
 import com.phu.backend.service.member.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -31,8 +30,8 @@ public class MemberController {
 
     @PostMapping("/sign-up/social")
     @Operation(summary = "소셜 회원가입", description = "사용자가 소셜 로그인 회원가입을 한다")
-    public void signUp(@RequestBody @Valid SignUpSocial request, HttpServletRequest servletRequest) {
-        memberService.signUpSocial(request, servletRequest);
+    public void signUp(@RequestBody @Valid SignUpSocial request) {
+        memberService.signUpSocial(request);
     }
 
     @PostMapping("/member/add")

--- a/src/main/java/com/phu/backend/dto/member/request/SignUpSocial.java
+++ b/src/main/java/com/phu/backend/dto/member/request/SignUpSocial.java
@@ -25,4 +25,7 @@ public class SignUpSocial {
     @Schema(description = "사용자 분류", nullable = false, example = "TRAINER")
     @NotNull
     private Part part;
+    @NotBlank(message = "소셜아이디를 입력해주세요")
+    @Schema(description = "사용자 소셜아이디", nullable = false, example = "소셜아이디")
+    private String socialId;
 }

--- a/src/main/java/com/phu/backend/service/member/MemberService.java
+++ b/src/main/java/com/phu/backend/service/member/MemberService.java
@@ -13,8 +13,6 @@ import com.phu.backend.exception.member.*;
 import com.phu.backend.exception.oauth.NotFoundSocialIdException;
 import com.phu.backend.repository.member.MemberListRepository;
 import com.phu.backend.repository.member.MemberRepository;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
@@ -55,19 +53,13 @@ public class MemberService {
     }
 
     @Transactional
-    public void signUpSocial(SignUpSocial request, HttpServletRequest servletRequest) {
-        String socialId = null;
-        Cookie[] cookies = servletRequest.getCookies();
-        for (Cookie cookie : cookies) {
-            if (cookie.getName().equals("social_id")) {
-                socialId = cookie.getValue();
-            }
-        }
-        if (socialId == null) {
+    public void signUpSocial(SignUpSocial request) {
+
+        if (memberRepository.findBySocialId(request.getSocialId()) == null) {
             throw new NotFoundSocialIdException();
         }
 
-        Member member = memberRepository.findBySocialId(socialId);
+        Member member = memberRepository.findBySocialId(request.getSocialId());
         String password = passwordEncoder.encode(request.getPassword());
 
         member.signUpForSocial(password, request.getAge(), request.getGender(), request.getTel(), request.getPart(), "ROLE_USER");


### PR DESCRIPTION
# 사용자가 처음으로 소셜로그인시 반환하는 데이터 예시

<br>

소셜아이디를 쿠키로 전송하는것이 아닌 JSON 형태로 클라이언트에게 전송 + 이메일 및 이름 추가 전송

<img width="868" alt="스크린샷 2024-10-13 오후 6 04 57" src="https://github.com/user-attachments/assets/52459b6e-396c-4f76-a014-3dd8d872262a">

<br>

## 소셜 회원가입 요청 데이터 예시

기존 데이터에서 소셜아이디 필드 추가

<img width="1443" alt="스크린샷 2024-10-13 오후 6 05 49" src="https://github.com/user-attachments/assets/3c4e6bcc-e759-48a9-948e-ff0bc961667d">

## 소셜 로그인 성공시

헤더에 엑세스토큰, 쿠키(Set-Cookie)에 리프레시토큰 반환

<img width="898" alt="스크린샷 2024-10-13 오후 6 07 08" src="https://github.com/user-attachments/assets/6182e882-3fa1-467e-9184-ded55c13a542">

close #25 
