### PR TITLE
[Refactor] 소셜 회원가입 로직 변경

### DIFF
--- a/src/main/java/com/phu/backend/config/SecurityConfig.java
+++ b/src/main/java/com/phu/backend/config/SecurityConfig.java
@@ -88,7 +88,6 @@ public class SecurityConfig {
                 .requestMatchers("/login", "/", "/sign-up", "/h2-console/**").permitAll()
                 .requestMatchers("/", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                 .requestMatchers("/reissue").permitAll()
-                .requestMatchers("/sign-up/social").permitAll()
                 .anyRequest().authenticated()
         );
 

--- a/src/main/java/com/phu/backend/domain/member/Member.java
+++ b/src/main/java/com/phu/backend/domain/member/Member.java
@@ -52,8 +52,7 @@ public class Member extends BaseTimeEntity {
         this.name = name;
     }
 
-    public void signUpForSocial(String password, Integer age, Gender gender, String tel, Part part, String role) {
-        this.password = password;
+    public void signUpForSocial(Integer age, Gender gender, String tel, Part part, String role) {
         this.age = age;
         this.gender = gender;
         this.tel = tel;

--- a/src/main/java/com/phu/backend/dto/member/request/SignUpSocial.java
+++ b/src/main/java/com/phu/backend/dto/member/request/SignUpSocial.java
@@ -10,9 +10,6 @@ import lombok.Getter;
 @Getter
 @Schema(description = "회원이 소셜로그인 회원가입시 필요한 추가적인 데이터")
 public class SignUpSocial {
-    @NotBlank(message = "비밀번호를 입력하세요")
-    @Schema(description = "사용자 비밀번호", nullable = false, example = "asdf1020")
-    private String password;
     @NotNull(message = "나이를 입력하세요")
     @Schema(description = "사용자 나이", nullable = false, example = "27")
     private Integer age;
@@ -25,7 +22,4 @@ public class SignUpSocial {
     @Schema(description = "사용자 분류", nullable = false, example = "TRAINER")
     @NotNull
     private Part part;
-    @NotBlank(message = "소셜아이디를 입력해주세요")
-    @Schema(description = "사용자 소셜아이디", nullable = false, example = "소셜아이디")
-    private String socialId;
 }

--- a/src/main/java/com/phu/backend/security/oauth/OAuthSuccessHandler.java
+++ b/src/main/java/com/phu/backend/security/oauth/OAuthSuccessHandler.java
@@ -48,11 +48,10 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
         log.info("username:{}", username);
         // 추가 회원가입
         if (role.equals("ROLE_BEFORE_USER")) {
-            response.setContentType("application/json; charset=UTF-8");
-            response.setCharacterEncoding("UTF-8");
-
-            String jsonResponse = "{\"email\": \"" + member.getEmail() + "\", \"name\": \"" + member.getName() + "\", \"social_id\": \"" + username + "\"}";
-            response.getWriter().write(jsonResponse);
+            // 클라이언트에게 유효기간 10분인 엑세스토큰 발급
+            String access = jwtUtil.createJwt("access", email, role);
+            response.setHeader("Authorization", "Bearer " + access);
+            response.sendRedirect("http://localhost:5173/social/sign-up");
         }
         // 소셜 로그인 진행 및 jwt 발급
         if (role.equals("ROLE_USER")) {
@@ -69,6 +68,7 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
             ResponseCookie refreshCookie = createRefreshCookie("refresh", refresh);
             response.setHeader("Set-Cookie", refreshCookie.toString());
             response.setHeader("Authorization", "Bearer " + access);
+            response.sendRedirect("http://localhost:5173/");
             log.info("token:{}", access);
         }
     }

--- a/src/main/java/com/phu/backend/service/member/MemberService.java
+++ b/src/main/java/com/phu/backend/service/member/MemberService.java
@@ -10,7 +10,6 @@ import com.phu.backend.dto.member.request.SignUpSocial;
 import com.phu.backend.dto.member.response.MemberInfoResponse;
 import com.phu.backend.dto.member.response.MemberResponse;
 import com.phu.backend.exception.member.*;
-import com.phu.backend.exception.oauth.NotFoundSocialIdException;
 import com.phu.backend.repository.member.MemberListRepository;
 import com.phu.backend.repository.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -54,15 +53,8 @@ public class MemberService {
 
     @Transactional
     public void signUpSocial(SignUpSocial request) {
-
-        if (memberRepository.findBySocialId(request.getSocialId()) == null) {
-            throw new NotFoundSocialIdException();
-        }
-
-        Member member = memberRepository.findBySocialId(request.getSocialId());
-        String password = passwordEncoder.encode(request.getPassword());
-
-        member.signUpForSocial(password, request.getAge(), request.getGender(), request.getTel(), request.getPart(), "ROLE_USER");
+        Member member = getMember();
+        member.signUpForSocial(request.getAge(), request.getGender(), request.getTel(), request.getPart(), "ROLE_USER");
     }
 
     public MemberResponse userInfo() {


### PR DESCRIPTION
## 흐름

<br>

**처음 소셜로그인시 엑세스토큰 발급**

<img width="1458" alt="스크린샷 2024-10-15 오후 2 46 55" src="https://github.com/user-attachments/assets/df6b79c7-0dfe-4d31-be49-40c232019b85">

**클라이언트는 서버에서 발급받은 엑세스토큰을 활용해 추가 회원가입을 진행한다.**

<img width="1198" alt="스크린샷 2024-10-15 오후 2 47 31" src="https://github.com/user-attachments/assets/88b05ee4-e9eb-4d23-ab1e-be45da3a6e07">

**추가회원가입 후 소셜로그인시 엑세스토큰과 리프레시 토큰을 발급해주는 모습**

<img width="1458" alt="스크린샷 2024-10-15 오후 2 50 34" src="https://github.com/user-attachments/assets/3cc57bed-e0d5-4902-93de-4945a15c65d3">


close #27 
