### PR TITLE
[Feat] 트레이너 회원 상세조회 및 추가정보 기입 API 설계

### DIFF
--- a/src/main/java/com/phu/backend/controller/member/MemberController.java
+++ b/src/main/java/com/phu/backend/controller/member/MemberController.java
@@ -1,10 +1,8 @@
 package com.phu.backend.controller.member;
 
-import com.phu.backend.dto.member.request.AddMemberRequest;
-import com.phu.backend.dto.member.request.MemberUpdateRequest;
-import com.phu.backend.dto.member.request.SignUpRequest;
-import com.phu.backend.dto.member.request.SignUpSocial;
+import com.phu.backend.dto.member.request.*;
 import com.phu.backend.dto.member.response.MemberInfoResponse;
+import com.phu.backend.dto.member.response.MemberMemoResponse;
 import com.phu.backend.dto.member.response.MemberResponse;
 import com.phu.backend.service.member.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -41,16 +39,22 @@ public class MemberController {
         return ResponseEntity.ok(memberService.addMember(request));
     }
 
+    @PostMapping("/pt/add/info/{member-list-id}")
+    @Operation(summary = "회원정보 입력", description = "트레이너가 추가한 회원의 상세정보를 입력받는다.")
+    public void addMemberInfo(@PathVariable(name = "member-list-id") Long id, @RequestBody @Valid AddMemberMemoRequest request) {
+        memberService.addMemberInfo(id,request);
+    }
+
+    @GetMapping("/pt/info/{member-list-id}")
+    @Operation(summary = "회원정보 상세조회", description = "트레이너의 회원정보를 상세조회한다.")
+    public ResponseEntity<MemberMemoResponse> getMemberInfo(@PathVariable(name = "member-list-id") Long id) {
+        return ResponseEntity.ok(memberService.getMyMemberInfo(id));
+    }
+
     @GetMapping("/member")
     @Operation(summary = "자기정보 조회", description = "사용자가 자기 정보를 조회한다")
     public ResponseEntity<MemberResponse> userInfo() {
         return ResponseEntity.ok().body(memberService.userInfo());
-    }
-
-    @GetMapping("/pt/member/{member-list-id}")
-    @Operation(summary = "회원 조회", description = "트레이너가 자신의 회원의 상세정보를 조회한다.")
-    public ResponseEntity<MemberResponse> memberInfo(@PathVariable(name = "member-list-id") Long id) {
-        return ResponseEntity.ok(memberService.getMyMemberInfo(id));
     }
 
     @GetMapping("/pt/member")

--- a/src/main/java/com/phu/backend/domain/member/MemberMemo.java
+++ b/src/main/java/com/phu/backend/domain/member/MemberMemo.java
@@ -1,0 +1,41 @@
+package com.phu.backend.domain.member;
+
+import com.phu.backend.global.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberMemo extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_memo_id")
+    private Long id;
+    private String memberTarget;
+    private String memberName;
+    private Integer memberAge;
+    private String significant;
+    private LocalDate ptStartDate;
+    private LocalDate ptEndDate;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trainer_id")
+    private Member trainer;
+    private String memberEmail;
+    @Builder
+    public MemberMemo(String memberTarget, String memberName, Integer memberAge, String significant, LocalDate ptStartDate, LocalDate ptEndDate, Member trainer, String memberEmail) {
+        this.memberTarget = memberTarget;
+        this.memberName = memberName;
+        this.memberAge = memberAge;
+        this.significant = significant;
+        this.ptStartDate = ptStartDate;
+        this.ptEndDate = ptEndDate;
+        this.trainer = trainer;
+        this.memberEmail = memberEmail;
+    }
+}

--- a/src/main/java/com/phu/backend/dto/member/request/AddMemberMemoRequest.java
+++ b/src/main/java/com/phu/backend/dto/member/request/AddMemberMemoRequest.java
@@ -1,0 +1,24 @@
+package com.phu.backend.dto.member.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class AddMemberMemoRequest {
+    @NotBlank(message = "목표를 설정해주세요")
+    @Schema(description = "회원 목표", nullable = false, example = "3대500")
+    private String memberTarget;
+    @NotBlank(message = "회원의 특이사항을 작성하세요")
+    @Schema(description = "회원 특이사항", nullable = false, example = "외반주 및 견갑골 불균형")
+    private String significant;
+    @NotNull(message = "PT시작 날짜를 입력해주세요")
+    @Schema(description = "PT 시작 날짜", nullable = false, example = "2024-10-23")
+    private LocalDate ptStartDate;
+    @NotNull(message = "PT종료 날짜를 입력해주세요")
+    @Schema(description = "PT 종료 날짜", nullable = false, example = "2024-12-23")
+    private LocalDate ptEndDate;
+}

--- a/src/main/java/com/phu/backend/dto/member/response/MemberMemoResponse.java
+++ b/src/main/java/com/phu/backend/dto/member/response/MemberMemoResponse.java
@@ -1,0 +1,26 @@
+package com.phu.backend.dto.member.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class MemberMemoResponse {
+    private String memberName;
+    private Integer memberAge;
+    private LocalDate ptStartDate;
+    private LocalDate ptEndDate;
+    private String memberTarget;
+    private String significant;
+
+    @Builder
+    public MemberMemoResponse(String memberName, Integer memberAge, LocalDate ptStartDate, LocalDate ptEndDate, String memberTarget, String significant) {
+        this.memberName = memberName;
+        this.memberAge = memberAge;
+        this.ptStartDate = ptStartDate;
+        this.ptEndDate = ptEndDate;
+        this.memberTarget = memberTarget;
+        this.significant = significant;
+    }
+}

--- a/src/main/java/com/phu/backend/repository/member/MemberMemoRepository.java
+++ b/src/main/java/com/phu/backend/repository/member/MemberMemoRepository.java
@@ -1,0 +1,10 @@
+package com.phu.backend.repository.member;
+
+import com.phu.backend.domain.member.MemberMemo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberMemoRepository extends JpaRepository<MemberMemo, Long> {
+    Optional<MemberMemo> findByMemberEmail(String email);
+}


### PR DESCRIPTION
# 추가정보 기입 명세

<br>

트레이너는 회원을 추가한 후 상세정보 기입 페이지로 이동하는 흐름

<img width="1452" alt="스크린샷 2024-10-23 오후 4 23 37" src="https://github.com/user-attachments/assets/1cc1f56b-786b-4ae5-a73e-588188883223">

<br>

반환

<img width="1429" alt="스크린샷 2024-10-23 오후 4 25 08" src="https://github.com/user-attachments/assets/dfc9b4f9-7413-4038-907e-31b77f667d16">

# 회원 상세정보 조회 

<br>

트레이너는 전체 회원 리스트에서 회원을 누를 시 회원의 상세정보 페이지로 이동하는 흐름

<img width="1453" alt="스크린샷 2024-10-23 오후 4 26 33" src="https://github.com/user-attachments/assets/dbd76690-5570-4d71-bdba-31851fc9b0b4">

<br>

반환

<img width="1436" alt="스크린샷 2024-10-23 오후 4 26 56" src="https://github.com/user-attachments/assets/fe53e227-663a-484e-819e-3d755e69196b">


close #33 

