### PR TITLE
[Feat] PT 진행 후 트레이너가 회원에 대해 기록하는 데일리차트 생성 및 상세조회 구현

### DIFF
--- a/src/main/java/com/phu/backend/controller/dailychart/DailyChartController.java
+++ b/src/main/java/com/phu/backend/controller/dailychart/DailyChartController.java
@@ -1,0 +1,29 @@
+package com.phu.backend.controller.dailychart;
+
+import com.phu.backend.dto.dailychart.request.PtDailyChartRequest;
+import com.phu.backend.dto.dailychart.response.DailyChartResponse;
+import com.phu.backend.service.dailychart.DailyChartService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "데일리차트 서비스 API", description = "데일리차트와 관련된 서비스를 제공하는 API")
+public class DailyChartController {
+    private final DailyChartService dailyChartService;
+    @PostMapping("/pt/chart")
+    @Operation(summary = "트레이너 -> 회원 데일리 차트 생성", description = "PT후 트레이너가 회원의 데일리 차트를 생성한다.")
+    public ResponseEntity<Long> addChartPt(@RequestBody @Valid PtDailyChartRequest request) {
+        return ResponseEntity.ok().body(dailyChartService.addChartPt(request));
+    }
+
+    @GetMapping("/chart/{chart-id}")
+    @Operation(summary = "데일리 차트 조회", description = "사용자가 데일리 차트를 상세조회한다.")
+    public ResponseEntity<DailyChartResponse> getDailyChart(@PathVariable(value = "chart-id") Long id) {
+        return ResponseEntity.ok().body(dailyChartService.getDailyCart(id));
+    }
+}

--- a/src/main/java/com/phu/backend/domain/dailychart/Branch.java
+++ b/src/main/java/com/phu/backend/domain/dailychart/Branch.java
@@ -1,0 +1,5 @@
+package com.phu.backend.domain.dailychart;
+
+public enum Branch {
+    PT, PERSONAL
+}

--- a/src/main/java/com/phu/backend/domain/dailychart/DailyChart.java
+++ b/src/main/java/com/phu/backend/domain/dailychart/DailyChart.java
@@ -1,0 +1,41 @@
+package com.phu.backend.domain.dailychart;
+
+import com.phu.backend.domain.member.Member;
+import com.phu.backend.global.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class DailyChart extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "daily_chart_id")
+    private Long id;
+    @Enumerated(value = EnumType.STRING)
+    private Branch branch;
+    private Integer weight;
+    private String memo;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member trainer;
+    private String memberEmail;
+    private LocalDate chartDate;
+//    @OneToMany(mappedBy = "DailyChart")
+//    private List<DailyChart> routines;
+        //TODO 사진추가
+    @Builder
+    public DailyChart(Branch branch, Integer weight, String memo, Member trainer, String memberEmail, LocalDate chartDate) {
+        this.branch = branch;
+        this.weight = weight;
+        this.memo = memo;
+        this.trainer = trainer;
+        this.memberEmail = memberEmail;
+        this.chartDate = chartDate;
+    }
+}

--- a/src/main/java/com/phu/backend/domain/dailychart/ExerciseArea.java
+++ b/src/main/java/com/phu/backend/domain/dailychart/ExerciseArea.java
@@ -1,0 +1,5 @@
+package com.phu.backend.domain.dailychart;
+
+public enum ExerciseArea {
+    CHEST, LEG, ARM, BACK, ABS, CARDIO
+}

--- a/src/main/java/com/phu/backend/domain/dailychart/Routine.java
+++ b/src/main/java/com/phu/backend/domain/dailychart/Routine.java
@@ -1,0 +1,26 @@
+package com.phu.backend.domain.dailychart;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Routine {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "routine_id")
+    private Long id;
+    @Enumerated(value = EnumType.STRING)
+    private ExerciseArea routine;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private DailyChart dailyChart;
+    @Builder
+    public Routine(ExerciseArea routine, DailyChart dailyChart) {
+        this.routine = routine;
+        this.dailyChart = dailyChart;
+    }
+}

--- a/src/main/java/com/phu/backend/dto/dailychart/request/PtDailyChartRequest.java
+++ b/src/main/java/com/phu/backend/dto/dailychart/request/PtDailyChartRequest.java
@@ -1,0 +1,26 @@
+package com.phu.backend.dto.dailychart.request;
+
+import com.phu.backend.domain.dailychart.Branch;
+import com.phu.backend.domain.dailychart.ExerciseArea;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class PtDailyChartRequest {
+    @NotNull(message = "차트를 추가할 회원의 아이디를 넣어주세요")
+    private Long id;
+    @NotNull(message = "차트 종류를 선택하세요")
+    @Schema(description = "차트 종류", nullable = false, example = "PT")
+    private Branch branch;
+    @NotNull
+    @Schema(description = "운동 날짜", nullable = false, example = "2024-10-29")
+    private LocalDate chartDate;
+    private Integer weight;
+    private String memo;
+    private List<ExerciseArea> routines = new ArrayList<>();
+}

--- a/src/main/java/com/phu/backend/dto/dailychart/response/DailyChartResponse.java
+++ b/src/main/java/com/phu/backend/dto/dailychart/response/DailyChartResponse.java
@@ -1,0 +1,32 @@
+package com.phu.backend.dto.dailychart.response;
+
+import com.phu.backend.domain.dailychart.Branch;
+import com.phu.backend.domain.dailychart.ExerciseArea;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class DailyChartResponse {
+    private Long id;
+    private Branch branch;
+    private LocalDate chartDate;
+    private Integer weight;
+    private String memo;
+    private List<ExerciseArea> routines = new ArrayList<>();
+
+    @Builder
+    public DailyChartResponse(Long id, Branch branch, LocalDate chartDate, Integer weight, String memo, List<ExerciseArea> routines) {
+        this.id = id;
+        this.branch = branch;
+        this.chartDate = chartDate;
+        this.weight = weight;
+        this.memo = memo;
+        this.routines = routines;
+    }
+}

--- a/src/main/java/com/phu/backend/dto/member/response/MemberMemoResponse.java
+++ b/src/main/java/com/phu/backend/dto/member/response/MemberMemoResponse.java
@@ -7,6 +7,7 @@ import java.time.LocalDate;
 
 @Getter
 public class MemberMemoResponse {
+    private Long id;
     private String memberName;
     private Integer memberAge;
     private LocalDate ptStartDate;
@@ -15,7 +16,8 @@ public class MemberMemoResponse {
     private String significant;
 
     @Builder
-    public MemberMemoResponse(String memberName, Integer memberAge, LocalDate ptStartDate, LocalDate ptEndDate, String memberTarget, String significant) {
+    public MemberMemoResponse(Long id, String memberName, Integer memberAge, LocalDate ptStartDate, LocalDate ptEndDate, String memberTarget, String significant) {
+        this.id = id;
         this.memberName = memberName;
         this.memberAge = memberAge;
         this.ptStartDate = ptStartDate;

--- a/src/main/java/com/phu/backend/exception/dailychart/BranchIsNotValidException.java
+++ b/src/main/java/com/phu/backend/exception/dailychart/BranchIsNotValidException.java
@@ -1,0 +1,15 @@
+package com.phu.backend.exception.dailychart;
+
+import com.phu.backend.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class BranchIsNotValidException extends GlobalException {
+    public static final String MESSAGE = "데일리 차트의 분기가 잘못됐습니다.";
+    @Override
+    public String getStatusCode() {
+        return "D001";
+    }
+    public BranchIsNotValidException() {
+        super(MESSAGE, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/phu/backend/exception/dailychart/NotFoundChartException.java
+++ b/src/main/java/com/phu/backend/exception/dailychart/NotFoundChartException.java
@@ -1,0 +1,15 @@
+package com.phu.backend.exception.dailychart;
+
+import com.phu.backend.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class NotFoundChartException extends GlobalException {
+    public static final String MESSAGE = "데일리 차트를 찾지 못했습니다.";
+    @Override
+    public String getStatusCode() {
+        return "D002";
+    }
+    public NotFoundChartException() {
+        super(MESSAGE, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/phu/backend/exception/member/MemberDuplicationException.java
+++ b/src/main/java/com/phu/backend/exception/member/MemberDuplicationException.java
@@ -1,0 +1,15 @@
+package com.phu.backend.exception.member;
+
+import com.phu.backend.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class MemberDuplicationException extends GlobalException {
+    public static final String MESSAGE = "자기 자신을 추가할 순 없습니다.";
+    @Override
+    public String getStatusCode() {
+        return "M007";
+    }
+    public MemberDuplicationException() {
+        super(MESSAGE, HttpStatus.NOT_ACCEPTABLE);
+    }
+}

--- a/src/main/java/com/phu/backend/repository/dailychart/DailyChartRepository.java
+++ b/src/main/java/com/phu/backend/repository/dailychart/DailyChartRepository.java
@@ -1,0 +1,7 @@
+package com.phu.backend.repository.dailychart;
+
+import com.phu.backend.domain.dailychart.DailyChart;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DailyChartRepository extends JpaRepository<DailyChart, Long> {
+}

--- a/src/main/java/com/phu/backend/repository/dailychart/RoutineRepository.java
+++ b/src/main/java/com/phu/backend/repository/dailychart/RoutineRepository.java
@@ -1,0 +1,11 @@
+package com.phu.backend.repository.dailychart;
+
+import com.phu.backend.domain.dailychart.DailyChart;
+import com.phu.backend.domain.dailychart.Routine;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface RoutineRepository extends JpaRepository<Routine, Long> {
+    List<Routine> findAllByDailyChart(DailyChart dailyChart);
+}

--- a/src/main/java/com/phu/backend/service/dailychart/DailyChartService.java
+++ b/src/main/java/com/phu/backend/service/dailychart/DailyChartService.java
@@ -5,11 +5,13 @@ import com.phu.backend.domain.dailychart.DailyChart;
 import com.phu.backend.domain.dailychart.ExerciseArea;
 import com.phu.backend.domain.dailychart.Routine;
 import com.phu.backend.domain.member.Member;
+import com.phu.backend.domain.member.Part;
 import com.phu.backend.dto.dailychart.request.PtDailyChartRequest;
 import com.phu.backend.dto.dailychart.response.DailyChartResponse;
 import com.phu.backend.exception.dailychart.BranchIsNotValidException;
 import com.phu.backend.exception.dailychart.NotFoundChartException;
 import com.phu.backend.exception.member.NotFoundMemberException;
+import com.phu.backend.exception.member.TrainerRoleException;
 import com.phu.backend.repository.dailychart.DailyChartRepository;
 import com.phu.backend.repository.dailychart.RoutineRepository;
 import com.phu.backend.repository.member.MemberRepository;
@@ -35,6 +37,10 @@ public class DailyChartService {
             throw new BranchIsNotValidException();
         }
         Member trainer = memberService.getMember();
+
+        if (trainer.getPart().equals(Part.MEMBER)) {
+            throw new TrainerRoleException();
+        }
 
         Member member = memberRepository.findById(request.getId())
                 .orElseThrow(NotFoundMemberException::new);

--- a/src/main/java/com/phu/backend/service/dailychart/DailyChartService.java
+++ b/src/main/java/com/phu/backend/service/dailychart/DailyChartService.java
@@ -10,6 +10,7 @@ import com.phu.backend.dto.dailychart.request.PtDailyChartRequest;
 import com.phu.backend.dto.dailychart.response.DailyChartResponse;
 import com.phu.backend.exception.dailychart.BranchIsNotValidException;
 import com.phu.backend.exception.dailychart.NotFoundChartException;
+import com.phu.backend.exception.member.MemberDuplicationException;
 import com.phu.backend.exception.member.NotFoundMemberException;
 import com.phu.backend.exception.member.TrainerRoleException;
 import com.phu.backend.repository.dailychart.DailyChartRepository;
@@ -44,6 +45,10 @@ public class DailyChartService {
 
         Member member = memberRepository.findById(request.getId())
                 .orElseThrow(NotFoundMemberException::new);
+
+        if (member.getId().equals(trainer.getId())) {
+            throw new MemberDuplicationException();
+        }
 
         DailyChart chart = DailyChart.builder()
                 .chartDate(request.getChartDate())

--- a/src/main/java/com/phu/backend/service/dailychart/DailyChartService.java
+++ b/src/main/java/com/phu/backend/service/dailychart/DailyChartService.java
@@ -1,0 +1,83 @@
+package com.phu.backend.service.dailychart;
+
+import com.phu.backend.domain.dailychart.Branch;
+import com.phu.backend.domain.dailychart.DailyChart;
+import com.phu.backend.domain.dailychart.ExerciseArea;
+import com.phu.backend.domain.dailychart.Routine;
+import com.phu.backend.domain.member.Member;
+import com.phu.backend.dto.dailychart.request.PtDailyChartRequest;
+import com.phu.backend.dto.dailychart.response.DailyChartResponse;
+import com.phu.backend.exception.dailychart.BranchIsNotValidException;
+import com.phu.backend.exception.dailychart.NotFoundChartException;
+import com.phu.backend.exception.member.NotFoundMemberException;
+import com.phu.backend.repository.dailychart.DailyChartRepository;
+import com.phu.backend.repository.dailychart.RoutineRepository;
+import com.phu.backend.repository.member.MemberRepository;
+import com.phu.backend.service.member.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class DailyChartService {
+    private final DailyChartRepository dailyChartRepository;
+    private final RoutineRepository routineRepository;
+    private final MemberRepository memberRepository;
+    private final MemberService memberService;
+
+    @Transactional
+    public Long addChartPt(PtDailyChartRequest request) {
+        if (request.getBranch().equals(Branch.PERSONAL)) {
+            throw new BranchIsNotValidException();
+        }
+        Member trainer = memberService.getMember();
+
+        Member member = memberRepository.findById(request.getId())
+                .orElseThrow(NotFoundMemberException::new);
+
+        DailyChart chart = DailyChart.builder()
+                .chartDate(request.getChartDate())
+                .trainer(trainer)
+                .memberEmail(member.getEmail())
+                .branch(request.getBranch())
+                .weight(request.getWeight())
+                .memo(request.getMemo())
+                .build();
+
+        dailyChartRepository.save(chart);
+
+        List<Routine> routines = request.getRoutines().stream()
+                .map(exerciseArea -> Routine.builder()
+                        .routine(exerciseArea)
+                        .dailyChart(chart)
+                        .build())
+                .collect(Collectors.toList());
+
+        routineRepository.saveAll(routines);
+
+        return chart.getId();
+    }
+
+    public DailyChartResponse getDailyCart(Long id) {
+        DailyChart dailyChart = dailyChartRepository.findById(id)
+                .orElseThrow(NotFoundChartException::new);
+
+        List<Routine> routines = routineRepository.findAllByDailyChart(dailyChart);
+
+        List<ExerciseArea> exerciseAreas = routines.stream()
+                .map(Routine::getRoutine).collect(Collectors.toList());
+
+        return DailyChartResponse.builder()
+                .id(dailyChart.getId())
+                .branch(dailyChart.getBranch())
+                .weight(dailyChart.getWeight())
+                .chartDate(dailyChart.getChartDate())
+                .routines(exerciseAreas)
+                .memo(dailyChart.getMemo())
+                .build();
+    }
+}

--- a/src/main/java/com/phu/backend/service/member/MemberService.java
+++ b/src/main/java/com/phu/backend/service/member/MemberService.java
@@ -119,7 +119,11 @@ public class MemberService {
         MemberMemo memberMemo = memberMemoRepository.findByMemberEmail(memberList.getMemberEmail())
                 .orElseThrow(NotFoundMemberException::new);
 
+        Member member = memberRepository.findByEmail(memberMemo.getMemberEmail())
+                .orElseThrow(NotFoundMemberException::new);
+
         return MemberMemoResponse.builder()
+                .id(member.getId())
                 .memberName(memberMemo.getMemberName())
                 .memberAge(memberMemo.getMemberAge())
                 .memberTarget(memberMemo.getMemberTarget())


### PR DESCRIPTION
## 명세

<br>

<img width="1458" alt="스크린샷 2024-10-29 오후 4 02 46" src="https://github.com/user-attachments/assets/a98960de-516c-47b2-988c-39d76761b21f">

<br>

### 트레이너 -> 회원 데일리차트 생성

<img width="1453" alt="스크린샷 2024-10-29 오후 4 04 18" src="https://github.com/user-attachments/assets/d1b17ccb-45c8-4c3d-9112-450cee36cdbc">

<br>

회원관리 목록에 회원이 존재하지 않을 시

<img width="1433" alt="스크린샷 2024-10-29 오후 5 03 50" src="https://github.com/user-attachments/assets/2c00b3fa-cf12-489c-b5d7-1c25184db665">

<br>

성공시 데일리차트 id 반환

<img width="1432" alt="스크린샷 2024-10-29 오후 5 04 40" src="https://github.com/user-attachments/assets/1c2e7996-3c00-4178-97c6-83be441ab922">

<br>

회원 조회 실패시

<img width="1422" alt="스크린샷 2024-10-29 오후 5 05 53" src="https://github.com/user-attachments/assets/3ce225b8-101b-4e5f-9eee-dc7ede396021">

<br>

### 작성한 데일리 차트 상세보기

<img width="1447" alt="스크린샷 2024-10-29 오후 5 06 35" src="https://github.com/user-attachments/assets/3341bdcd-49bd-4bdc-994d-968ae7d009ef">

<br>

<img width="1438" alt="스크린샷 2024-10-29 오후 5 07 05" src="https://github.com/user-attachments/assets/664e9e85-f048-41dd-91db-911895ba769d">

close #35 
