### PR TITLE
[Feat] 회원이 개인운동시 작성하는 데일리차트 구현

### DIFF
--- a/src/main/java/com/phu/backend/controller/dailychart/DailyChartController.java
+++ b/src/main/java/com/phu/backend/controller/dailychart/DailyChartController.java
@@ -1,6 +1,8 @@
 package com.phu.backend.controller.dailychart;
 
+import com.phu.backend.dto.dailychart.request.MemberDailyChartRequest;
 import com.phu.backend.dto.dailychart.request.PtDailyChartRequest;
+import com.phu.backend.dto.dailychart.response.DailyChartListResponse;
 import com.phu.backend.dto.dailychart.response.DailyChartResponse;
 import com.phu.backend.service.dailychart.DailyChartService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,6 +11,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,9 +25,21 @@ public class DailyChartController {
         return ResponseEntity.ok().body(dailyChartService.addChartPt(request));
     }
 
+    @PostMapping("/member/chart")
+    @Operation(summary = "회원(개인운동) 데일리 차트 생성", description = "회원이 개인운동 후 데일리 차트를 생성한다.")
+    public ResponseEntity<Long> addChartMember(@RequestBody @Valid MemberDailyChartRequest request) {
+        return ResponseEntity.ok().body(dailyChartService.addChartMember(request));
+    }
+
     @GetMapping("/chart/{chart-id}")
     @Operation(summary = "데일리 차트 조회", description = "사용자가 데일리 차트를 상세조회한다.")
-    public ResponseEntity<DailyChartResponse> getDailyChart(@PathVariable(value = "chart-id") Long id) {
+    public ResponseEntity<DailyChartResponse> getDailyChart(@PathVariable(name = "chart-id") Long id) {
         return ResponseEntity.ok().body(dailyChartService.getDailyCart(id));
+    }
+
+    @GetMapping("/chart/all/{member-id}")
+    @Operation(summary = "회원별 데일리 차트 전체조회", description = "회원별 데일리 차트를 전체조회한다.")
+    public ResponseEntity<List<DailyChartListResponse>> getAllDailyChart(@PathVariable(name = "member-id") Long id) {
+        return ResponseEntity.ok().body(dailyChartService.getAllDailyCart(id));
     }
 }

--- a/src/main/java/com/phu/backend/dto/dailychart/request/MemberDailyChartRequest.java
+++ b/src/main/java/com/phu/backend/dto/dailychart/request/MemberDailyChartRequest.java
@@ -1,0 +1,21 @@
+package com.phu.backend.dto.dailychart.request;
+
+import com.phu.backend.domain.dailychart.ExerciseArea;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class MemberDailyChartRequest {
+    @NotNull(message = "운동 기록 날짜를 입력해주세요")
+    @Schema(description = "운동 날짜", nullable = false, example = "2024-10-29")
+    private LocalDate chartDate;
+    private Integer weight;
+    private String memo;
+    @NotNull(message = "어느 부위를 운동했는지 기록하세요")
+    private List<ExerciseArea> routines = new ArrayList<>();
+}

--- a/src/main/java/com/phu/backend/dto/dailychart/request/PtDailyChartRequest.java
+++ b/src/main/java/com/phu/backend/dto/dailychart/request/PtDailyChartRequest.java
@@ -17,7 +17,7 @@ public class PtDailyChartRequest {
     @NotNull(message = "차트 종류를 선택하세요")
     @Schema(description = "차트 종류", nullable = false, example = "PT")
     private Branch branch;
-    @NotNull
+    @NotNull(message = "운동 기록 날짜를 입력해주세요")
     @Schema(description = "운동 날짜", nullable = false, example = "2024-10-29")
     private LocalDate chartDate;
     private Integer weight;

--- a/src/main/java/com/phu/backend/dto/dailychart/response/DailyChartListResponse.java
+++ b/src/main/java/com/phu/backend/dto/dailychart/response/DailyChartListResponse.java
@@ -1,0 +1,39 @@
+package com.phu.backend.dto.dailychart.response;
+
+import com.phu.backend.domain.dailychart.Branch;
+import com.phu.backend.domain.dailychart.DailyChart;
+import com.phu.backend.domain.dailychart.ExerciseArea;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class DailyChartListResponse {
+    private Long id;
+    private Branch branch;
+    private LocalDate chartDate;
+    private List<ExerciseArea> routines = new ArrayList<>();
+
+    public DailyChartListResponse(DailyChart dailyCharts) {
+        this.id = dailyCharts.getId();
+        this.branch = dailyCharts.getBranch();
+        this.chartDate = dailyCharts.getChartDate();
+    }
+
+    public void confirmRoutines(List<ExerciseArea> exerciseAreas) {
+        this.routines = exerciseAreas;
+    }
+
+    @Builder
+    public DailyChartListResponse(Long id, Branch branch, LocalDate chartDate, List<ExerciseArea> routines) {
+        this.id = id;
+        this.branch = branch;
+        this.chartDate = chartDate;
+        this.routines = routines;
+    }
+}

--- a/src/main/java/com/phu/backend/exception/dailychart/NotConnectedToTrainerException.java
+++ b/src/main/java/com/phu/backend/exception/dailychart/NotConnectedToTrainerException.java
@@ -1,0 +1,15 @@
+package com.phu.backend.exception.dailychart;
+
+import com.phu.backend.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class NotConnectedToTrainerException extends GlobalException {
+    public static final String MESSAGE = "해당회원은 피티를 받고있는 회원이 아닙니다.";
+    @Override
+    public String getStatusCode() {
+        return "D004";
+    }
+    public NotConnectedToTrainerException() {
+        super(MESSAGE, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/phu/backend/repository/dailychart/DailyChartRepository.java
+++ b/src/main/java/com/phu/backend/repository/dailychart/DailyChartRepository.java
@@ -1,7 +1,12 @@
 package com.phu.backend.repository.dailychart;
 
 import com.phu.backend.domain.dailychart.DailyChart;
+import com.phu.backend.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface DailyChartRepository extends JpaRepository<DailyChart, Long> {
+    List<DailyChart> findAllByTrainerAndMemberEmail(Member trainer, String email);
+    List<DailyChart> findAllByMemberEmail(String email);
 }

--- a/src/main/java/com/phu/backend/repository/member/MemberListRepository.java
+++ b/src/main/java/com/phu/backend/repository/member/MemberListRepository.java
@@ -12,4 +12,6 @@ public interface MemberListRepository extends JpaRepository<MemberList, Long> {
     Optional<MemberList> findByTrainerAndMemberEmail(Member member, String email);
 
     List<MemberList> findAllByTrainer(Member member);
+
+    Optional<MemberList> findByMemberEmail(String email);
 }


### PR DESCRIPTION
# 명세

<img width="1452" alt="스크린샷 2024-11-04 오전 10 44 23" src="https://github.com/user-attachments/assets/f5aa3ef7-cb6a-4d74-be6c-d3c5c83a7b1a">

<br>

### 피티를 받고있지 않는 회원이 작성할시

<img width="1435" alt="스크린샷 2024-11-04 오전 10 45 08" src="https://github.com/user-attachments/assets/bdcb0d9c-c511-43f2-9a02-4d43f3b05d4b">


### 해당 회원과 연결된 트레이너는 피티일지가 아닌 회원이 개인운동시 운동의 정보를 확인할 수 있다.

<img width="1432" alt="스크린샷 2024-11-04 오전 10 48 10" src="https://github.com/user-attachments/assets/bfc4b775-f575-426a-9542-08147e932c0a">

close #37 
