### PR TITLE
[Feat] 음성파일을 핸들링하기 위한 도메인 설계

### DIFF
--- a/src/main/java/com/phu/backend/domain/voicefile/VoiceFile.java
+++ b/src/main/java/com/phu/backend/domain/voicefile/VoiceFile.java
@@ -1,0 +1,30 @@
+package com.phu.backend.domain.voicefile;
+
+import com.phu.backend.domain.member.Member;
+import com.phu.backend.global.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class VoiceFile extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "voice_file_id")
+    private Long id;
+    private String fileName;
+    private String uploadFileUrl;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member trainer;
+
+    @Builder
+    public VoiceFile(String fileName, String uploadFileUrl, Member trainer) {
+        this.fileName = fileName;
+        this.uploadFileUrl = uploadFileUrl;
+        this.trainer = trainer;
+    }
+}

--- a/src/main/java/com/phu/backend/repository/voicefile/VoiceFileRepository.java
+++ b/src/main/java/com/phu/backend/repository/voicefile/VoiceFileRepository.java
@@ -1,0 +1,7 @@
+package com.phu.backend.repository.voicefile;
+
+import com.phu.backend.domain.voicefile.VoiceFile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VoiceFileRepository extends JpaRepository<VoiceFile, Long> {
+}

--- a/src/main/java/com/phu/backend/service/voicefile/VoiceFileService.java
+++ b/src/main/java/com/phu/backend/service/voicefile/VoiceFileService.java
@@ -4,11 +4,18 @@ import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.*;
+import com.phu.backend.domain.member.Member;
+import com.phu.backend.domain.member.Part;
+import com.phu.backend.domain.voicefile.VoiceFile;
 import com.phu.backend.dto.voicefile.response.VoiceFileResponse;
+import com.phu.backend.exception.member.TrainerRoleException;
+import com.phu.backend.repository.voicefile.VoiceFileRepository;
+import com.phu.backend.service.member.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
@@ -22,10 +29,19 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class VoiceFileService {
     private final AmazonS3Client s3;
+    private final VoiceFileRepository voiceFileRepository;
+    private final MemberService memberService;
     @Value("${ncp.s3.bucket}")
     private String bucketName;
 
+    @Transactional
     public VoiceFileResponse uploadVoiceFile(MultipartFile multipartFile) {
+        Member trainer = memberService.getMember();
+
+        if (!trainer.getPart().equals(Part.TRAINER)) {
+            throw new TrainerRoleException();
+        }
+
         // 객체 이름을 고유하게 생성 (예: UUID 사용)
         String objectName = UUID.randomUUID().toString() + "_" + multipartFile.getOriginalFilename();
 
@@ -72,6 +88,14 @@ public class VoiceFileService {
 
             // 객체 URL 생성
             String objectUrl = s3.getUrl(bucketName, objectName).toString();
+
+            VoiceFile voiceFile = VoiceFile.builder()
+                    .fileName(objectName)
+                    .uploadFileUrl(objectUrl)
+                    .trainer(trainer)
+                    .build();
+
+            voiceFileRepository.save(voiceFile);
 
             return VoiceFileResponse.builder()
                     .uploadFileUrl(objectUrl)


### PR DESCRIPTION
## 음성파일 저장 시 트레이너가 아닐 시

<img width="835" alt="스크린샷 2024-11-12 오후 5 01 30" src="https://github.com/user-attachments/assets/8b4f1c0e-964a-44e4-a350-304901744162">

## 음성파일 저장 후

<img width="1049" alt="스크린샷 2024-11-12 오후 5 02 33" src="https://github.com/user-attachments/assets/7055a1a4-6b86-4017-9199-0445e48fdeea">

음성 파일마다 중복되지 않는 고유한 id 적용

close #44 