### PR TITLE
[Feat] 음성녹음 기록 텍스트 추출 조회 API 설계 기능구현

### DIFF
--- a/src/main/java/com/phu/backend/controller/clova/ClovaController.java
+++ b/src/main/java/com/phu/backend/controller/clova/ClovaController.java
@@ -1,7 +1,7 @@
 package com.phu.backend.controller.clova;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.phu.backend.dto.clova.ClovaSpeechResponse;
+import com.phu.backend.dto.clova.ClovaSpeechResponseList;
 import com.phu.backend.service.clova.ClovaService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -10,16 +10,14 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
 @RestController
 @RequiredArgsConstructor
 public class ClovaController {
     private final ClovaService clovaService;
     @GetMapping("/pt/clova/{member-id}/{file-id}")
     @Operation(summary = "음성메모 텍스트 추출", description = "음성메모의 텍스트를 분석해 추출한다.")
-    public ResponseEntity<List<ClovaSpeechResponse>> uploadVoiceFile(@PathVariable(name = "file-id") Long fileId,
-                                                                     @PathVariable(name = "member-id") Long memberId) throws JsonProcessingException {
+    public ResponseEntity<ClovaSpeechResponseList> uploadVoiceFile(@PathVariable(name = "file-id") Long fileId,
+                                                                   @PathVariable(name = "member-id") Long memberId) throws JsonProcessingException {
         return ResponseEntity.ok().body(clovaService.clovaSpeech(fileId, memberId));
     }
 }

--- a/src/main/java/com/phu/backend/controller/voicefile/VoiceFileController.java
+++ b/src/main/java/com/phu/backend/controller/voicefile/VoiceFileController.java
@@ -1,5 +1,6 @@
 package com.phu.backend.controller.voicefile;
 
+import com.phu.backend.dto.clova.ClovaSpeechResponseList;
 import com.phu.backend.dto.voicefile.response.VoiceFileListResponse;
 import com.phu.backend.dto.voicefile.response.VoiceFileResponse;
 import com.phu.backend.service.voicefile.VoiceFileService;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,5 +28,12 @@ public class VoiceFileController {
     @Operation(summary = "연결된 회원과의 음성파일 리스트 조회", description = "저장된 음성파일 리스트를 전체조회한다.")
     public ResponseEntity<List<VoiceFileListResponse>> getVoiceFileList(@PathVariable(name = "member-id") Long id) {
         return ResponseEntity.ok().body(voiceFileService.getList(id));
+    }
+
+    @GetMapping("/pt/voice-file/result/{voice-file-id}/{voice-list-id}")
+    @Operation(summary = "음성녹음 텍스트 결과 조회", description = "추출한 음성파일 텍스트를 조회한다.")
+    public ResponseEntity<ClovaSpeechResponseList> getVoiceFileList(@PathVariable(name = "voice-list-id") UUID voiceId,
+                                                                    @PathVariable(name = "voice-file-id") Long fileId) {
+        return ResponseEntity.ok().body(voiceFileService.getVoiceText(voiceId, fileId));
     }
 }

--- a/src/main/java/com/phu/backend/domain/clovavoicetext/ClovaVoiceText.java
+++ b/src/main/java/com/phu/backend/domain/clovavoicetext/ClovaVoiceText.java
@@ -1,5 +1,6 @@
 package com.phu.backend.domain.clovavoicetext;
 
+import com.phu.backend.dto.clova.ClovaSpeechResponse;
 import com.phu.backend.global.BaseTimeEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -8,6 +9,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 
+import java.util.List;
 import java.util.UUID;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -16,16 +18,14 @@ import java.util.UUID;
 public class ClovaVoiceText extends BaseTimeEntity {
     @Id
     private UUID id;
-    private String speaker;
-    private String text;
+    private List<ClovaSpeechResponse> voiceList;
     private Long trainerId;
     private Long memberId;
 
     @Builder
-    public ClovaVoiceText(UUID id, String speaker, String text, Long trainerId, Long memberId) {
+    public ClovaVoiceText(UUID id, List<ClovaSpeechResponse> voiceList, Long trainerId, Long memberId) {
         this.id = id;
-        this.speaker = speaker;
-        this.text = text;
+        this.voiceList = voiceList;
         this.trainerId = trainerId;
         this.memberId = memberId;
     }

--- a/src/main/java/com/phu/backend/domain/voicefile/VoiceFile.java
+++ b/src/main/java/com/phu/backend/domain/voicefile/VoiceFile.java
@@ -21,12 +21,17 @@ public class VoiceFile extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Member trainer;
     private Long memberId;
+    private Boolean isTransformation;
 
+    public void enableTransformation() {
+        this.isTransformation = true;
+    }
     @Builder
-    public VoiceFile(String fileName, String uploadFileUrl, Member trainer, Long memberId) {
+    public VoiceFile(String fileName, String uploadFileUrl, Member trainer, Long memberId, Boolean isTransformation) {
         this.fileName = fileName;
         this.uploadFileUrl = uploadFileUrl;
         this.trainer = trainer;
         this.memberId = memberId;
+        this.isTransformation = isTransformation;
     }
 }

--- a/src/main/java/com/phu/backend/dto/clova/ClovaSpeechResponseList.java
+++ b/src/main/java/com/phu/backend/dto/clova/ClovaSpeechResponseList.java
@@ -1,9 +1,11 @@
 package com.phu.backend.dto.clova;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -11,11 +13,16 @@ import java.util.UUID;
 @NoArgsConstructor
 public class ClovaSpeechResponseList {
     private UUID voiceListId;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime createAt;
+    private String memberName;
     private List<ClovaSpeechResponse> list;
 
     @Builder
-    public ClovaSpeechResponseList(UUID voiceListId, List<ClovaSpeechResponse> list) {
+    public ClovaSpeechResponseList(UUID voiceListId, LocalDateTime createAt, String memberName, List<ClovaSpeechResponse> list) {
         this.voiceListId = voiceListId;
+        this.createAt = createAt;
+        this.memberName = memberName;
         this.list = list;
     }
 }

--- a/src/main/java/com/phu/backend/dto/clova/ClovaSpeechResponseList.java
+++ b/src/main/java/com/phu/backend/dto/clova/ClovaSpeechResponseList.java
@@ -1,0 +1,21 @@
+package com.phu.backend.dto.clova;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+public class ClovaSpeechResponseList {
+    private UUID voiceListId;
+    private List<ClovaSpeechResponse> list;
+
+    @Builder
+    public ClovaSpeechResponseList(UUID voiceListId, List<ClovaSpeechResponse> list) {
+        this.voiceListId = voiceListId;
+        this.list = list;
+    }
+}

--- a/src/main/java/com/phu/backend/dto/voicefile/response/VoiceFileListResponse.java
+++ b/src/main/java/com/phu/backend/dto/voicefile/response/VoiceFileListResponse.java
@@ -11,23 +11,27 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor
 public class VoiceFileListResponse {
-    private Long id;
+    private Long fileId;
     private String uploadFileUrl;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime createAt;
     private Long memberId;
+    private Boolean isTransformation;
 
     public VoiceFileListResponse(VoiceFile voiceFile) {
-        this.id = voiceFile.getId();
+        this.fileId = voiceFile.getId();
         this.uploadFileUrl = voiceFile.getUploadFileUrl();
         this.createAt = voiceFile.getCreatedAt();
         this.memberId = voiceFile.getMemberId();
+        this.isTransformation = voiceFile.getIsTransformation();
     }
+
     @Builder
-    public VoiceFileListResponse(Long id, String uploadFileUrl, LocalDateTime createAt, Long memberId) {
-        this.id = id;
+    public VoiceFileListResponse(Long fileId, String uploadFileUrl, LocalDateTime createAt, Long memberId, Boolean isTransformation) {
+        this.fileId = fileId;
         this.uploadFileUrl = uploadFileUrl;
         this.createAt = createAt;
         this.memberId = memberId;
+        this.isTransformation = isTransformation;
     }
 }

--- a/src/main/java/com/phu/backend/dto/voicefile/response/VoiceFileResponse.java
+++ b/src/main/java/com/phu/backend/dto/voicefile/response/VoiceFileResponse.java
@@ -7,20 +7,22 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class VoiceFileResponse {
-    private Long id;
+    private Long fileId;
     private String originalFileName;
     private String uploadFileName;
     private String uploadFileUrl;
     private String message;
     private Long memberId;
+    private Boolean isTransformation;
 
     @Builder
-    public VoiceFileResponse(Long id, String originalFileName, String uploadFileName, String uploadFileUrl, String message, Long memberId) {
-        this.id = id;
+    public VoiceFileResponse(Long fileId, String originalFileName, String uploadFileName, String uploadFileUrl, String message, Long memberId, Boolean isTransformation) {
+        this.fileId = fileId;
         this.originalFileName = originalFileName;
         this.uploadFileName = uploadFileName;
         this.uploadFileUrl = uploadFileUrl;
         this.message = message;
         this.memberId = memberId;
+        this.isTransformation = isTransformation;
     }
 }

--- a/src/main/java/com/phu/backend/exception/voicefile/NotFoundVoiceDataException.java
+++ b/src/main/java/com/phu/backend/exception/voicefile/NotFoundVoiceDataException.java
@@ -1,0 +1,15 @@
+package com.phu.backend.exception.voicefile;
+
+import com.phu.backend.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class NotFoundVoiceDataException extends GlobalException {
+    public static final String MESSAGE = "텍스트 변환 데이터를 찾을 수 없습니다.";
+    @Override
+    public String getStatusCode() {
+        return "VF003";
+    }
+    public NotFoundVoiceDataException() {
+        super(MESSAGE, HttpStatus.NOT_ACCEPTABLE);
+    }
+}

--- a/src/main/java/com/phu/backend/service/voicefile/VoiceFileService.java
+++ b/src/main/java/com/phu/backend/service/voicefile/VoiceFileService.java
@@ -169,4 +169,21 @@ public class VoiceFileService {
         return voiceFiles.stream().map(VoiceFileListResponse::new)
                 .collect(Collectors.toList());
     }
+
+    public ClovaSpeechResponseList getVoiceText(UUID voiceId, Long fileId) {
+        ClovaVoiceText clovaVoiceText = clovaVoiceTextRepository.findById(voiceId)
+                .orElseThrow(NotFoundVoiceDataException::new);
+
+        Member member = memberRepository.findById(clovaVoiceText.getMemberId())
+                .orElseThrow(NotFoundMemberException::new);
+
+        VoiceFile voiceFile = voiceFileRepository.findById(fileId).orElseThrow(NotFoundFileException::new);
+
+        return ClovaSpeechResponseList.builder()
+                .voiceListId(clovaVoiceText.getId())
+                .list(clovaVoiceText.getVoiceList())
+                .memberName(member.getName())
+                .createAt(voiceFile.getCreatedAt())
+                .build();
+    }
 }

--- a/src/main/java/com/phu/backend/service/voicefile/VoiceFileService.java
+++ b/src/main/java/com/phu/backend/service/voicefile/VoiceFileService.java
@@ -4,12 +4,19 @@ import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.*;
+import com.phu.backend.domain.clovavoicetext.ClovaVoiceText;
 import com.phu.backend.domain.member.Member;
 import com.phu.backend.domain.member.Part;
 import com.phu.backend.domain.voicefile.VoiceFile;
+import com.phu.backend.dto.clova.ClovaSpeechResponseList;
 import com.phu.backend.dto.voicefile.response.VoiceFileListResponse;
 import com.phu.backend.dto.voicefile.response.VoiceFileResponse;
+import com.phu.backend.exception.member.NotFoundMemberException;
 import com.phu.backend.exception.member.TrainerRoleException;
+import com.phu.backend.exception.voicefile.NotFoundFileException;
+import com.phu.backend.exception.voicefile.NotFoundVoiceDataException;
+import com.phu.backend.repository.clovavoicetext.ClovaVoiceTextRepository;
+import com.phu.backend.repository.member.MemberRepository;
 import com.phu.backend.repository.voicefile.VoiceFileRepository;
 import com.phu.backend.service.member.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +40,8 @@ public class VoiceFileService {
     private final AmazonS3Client s3;
     private final VoiceFileRepository voiceFileRepository;
     private final MemberService memberService;
+    private final MemberRepository memberRepository;
+    private final ClovaVoiceTextRepository clovaVoiceTextRepository;
     @Value("${ncp.s3.bucket}")
     private String bucketName;
 
@@ -96,17 +105,19 @@ public class VoiceFileService {
                     .uploadFileUrl(objectUrl)
                     .trainer(trainer)
                     .memberId(id)
+                    .isTransformation(false)
                     .build();
 
             voiceFileRepository.save(voiceFile);
 
             return VoiceFileResponse.builder()
-                    .id(voiceFile.getId())
+                    .fileId(voiceFile.getId())
                     .uploadFileUrl(objectUrl)
                     .originalFileName(multipartFile.getOriginalFilename())
                     .uploadFileName(objectName)
                     .message("SUCCESS")
                     .memberId(id)
+                    .isTransformation(voiceFile.getIsTransformation())
                     .build();
 
         } catch (AmazonServiceException e) {


### PR DESCRIPTION
# 명세

- voiceList의 id값과 voiceFile의 id으로 추출한 텍스트 데이터를 조회합니다.

<img width="1439" alt="스크린샷 2024-12-04 오후 3 49 22" src="https://github.com/user-attachments/assets/e99d7a98-1ebf-4a93-8f1b-d60c01881580">

<br>

- 음성녹음 완료(서버에 전송시) 응답 데이터

<img width="860" alt="스크린샷 2024-12-04 오후 3 52 08" src="https://github.com/user-attachments/assets/8b5e9acb-a24c-4650-92c9-727c9e955fa2">

<br>

-  연결된 회원과의 음성녹음 전체조회시 응답 데이터
-  회원id 반환 및 텍스트 변환 여부를 판별하는 isTransformation 데이터 추가

<img width="843" alt="스크린샷 2024-12-04 오후 3 53 02" src="https://github.com/user-attachments/assets/5d0b2e35-ecea-49a9-a78b-2eb3ff789d8e">

<br>

- 음성메모 텍스트 추출

<img width="1454" alt="스크린샷 2024-12-04 오후 3 55 43" src="https://github.com/user-attachments/assets/e6af5645-9681-4c24-9861-22317cadf0f8">

- 응답값으로 voiceListId(UUID) 값 반환

<img width="1425" alt="스크린샷 2024-12-04 오후 3 55 08" src="https://github.com/user-attachments/assets/185bdd17-2557-41ec-ba68-8eb2e1f97c96">

- 음성녹음 리스트 조회시 음성녹음파일 id와 위의 voiceListId를 이용해 텍스트 기록 조회

<img width="1452" alt="스크린샷 2024-12-04 오후 3 57 37" src="https://github.com/user-attachments/assets/3f40a7f7-83df-444f-bc7e-591d4435ad45">


close #53 