### PR TITLE
[Feat] 데일리 차트 수정 API 설계

### DIFF
--- a/src/main/java/com/phu/backend/controller/dailychart/DailyChartController.java
+++ b/src/main/java/com/phu/backend/controller/dailychart/DailyChartController.java
@@ -1,6 +1,7 @@
 package com.phu.backend.controller.dailychart;
 
 import com.phu.backend.dto.dailychart.request.DailyChartRequest;
+import com.phu.backend.dto.dailychart.request.UpdateDailyChartRequest;
 import com.phu.backend.dto.dailychart.response.DailyChartListResponse;
 import com.phu.backend.dto.dailychart.response.DailyChartResponse;
 import com.phu.backend.service.dailychart.DailyChartService;
@@ -39,7 +40,14 @@ public class DailyChartController {
 
     @GetMapping("/chart/all/{member-id}")
     @Operation(summary = "회원별 데일리 차트 전체조회", description = "회원별 데일리 차트를 전체조회한다.")
-    public ResponseEntity<List<DailyChartListResponse>> getAllDailyChart(@PathVariable(name = "member-id") Long id) {
-        return ResponseEntity.ok().body(dailyChartService.getAllDailyCart(id));
+    public ResponseEntity<List<DailyChartListResponse>> getAllDailyChart(@PathVariable(name = "member-id") Long memberId) {
+        return ResponseEntity.ok().body(dailyChartService.getAllDailyCart(memberId));
+    }
+
+    @PutMapping("/chart/{chart-id}")
+    @Operation(summary = "데일리차트 수정", description = "작성한 데일리 차트를 수정한다.")
+    public void updateDailyChart(@RequestBody @Valid UpdateDailyChartRequest request,
+                                 @PathVariable(name = "chart-id") Long chartId) {
+        dailyChartService.updateDailyChart(request,chartId);
     }
 }

--- a/src/main/java/com/phu/backend/domain/dailychart/DailyChart.java
+++ b/src/main/java/com/phu/backend/domain/dailychart/DailyChart.java
@@ -29,6 +29,12 @@ public class DailyChart extends BaseTimeEntity {
 //    @OneToMany(mappedBy = "DailyChart")
 //    private List<DailyChart> routines;
         //TODO 사진추가
+
+    public void updateChart(LocalDate chartDate, Integer weight, String memo) {
+        this.chartDate = chartDate;
+        this.weight = weight;
+        this.memo = memo;
+    }
     @Builder
     public DailyChart(Branch branch, Integer weight, String memo, Member trainer, String memberEmail, LocalDate chartDate) {
         this.branch = branch;

--- a/src/main/java/com/phu/backend/domain/dailychart/Routine.java
+++ b/src/main/java/com/phu/backend/domain/dailychart/Routine.java
@@ -18,6 +18,10 @@ public class Routine {
     private ExerciseArea routine;
     @ManyToOne(fetch = FetchType.LAZY)
     private DailyChart dailyChart;
+
+    public void updateRoutine(ExerciseArea routine) {
+        this.routine = routine;
+    }
     @Builder
     public Routine(ExerciseArea routine, DailyChart dailyChart) {
         this.routine = routine;

--- a/src/main/java/com/phu/backend/dto/dailychart/request/UpdateDailyChartRequest.java
+++ b/src/main/java/com/phu/backend/dto/dailychart/request/UpdateDailyChartRequest.java
@@ -1,6 +1,5 @@
 package com.phu.backend.dto.dailychart.request;
 
-import com.phu.backend.domain.dailychart.Branch;
 import com.phu.backend.domain.dailychart.ExerciseArea;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -11,12 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Getter
-public class PtDailyChartRequest {
-    @NotNull(message = "차트를 추가할 회원의 아이디를 넣어주세요")
-    private Long id;
-    @NotNull(message = "차트 종류를 선택하세요")
-    @Schema(description = "차트 종류", nullable = false, example = "PT")
-    private Branch branch;
+public class UpdateDailyChartRequest {
     @NotNull(message = "운동 기록 날짜를 입력해주세요")
     @Schema(description = "운동 날짜", nullable = false, example = "2024-10-29")
     private LocalDate chartDate;

--- a/src/main/java/com/phu/backend/exception/member/MemberRoleException.java
+++ b/src/main/java/com/phu/backend/exception/member/MemberRoleException.java
@@ -1,0 +1,15 @@
+package com.phu.backend.exception.member;
+
+import com.phu.backend.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class MemberRoleException extends GlobalException {
+    public static final String MESSAGE = "해당 기능은 회원만 가능합니다.";
+    @Override
+    public String getStatusCode() {
+        return "M008";
+    }
+    public MemberRoleException() {
+        super(MESSAGE, HttpStatus.NOT_ACCEPTABLE);
+    }
+}


### PR DESCRIPTION
# 명세

<img width="1438" alt="스크린샷 2024-12-10 오후 7 43 01" src="https://github.com/user-attachments/assets/d336bdff-c326-4e76-bc5d-301ebaf673ce">

<br>

## 수정 전

<img width="1412" alt="스크린샷 2024-12-10 오후 7 44 21" src="https://github.com/user-attachments/assets/ec9b52c5-2019-49d5-b645-26fbe8f98550">


## 수정 후

<img width="1416" alt="스크린샷 2024-12-10 오후 7 45 09" src="https://github.com/user-attachments/assets/c7ae27f6-73ee-4864-92a6-62f9a1f35c69">


## 회원이 트레이너가 쓴 데일리 차트를 수정하려 할 때

<img width="1427" alt="스크린샷 2024-12-10 오후 7 46 03" src="https://github.com/user-attachments/assets/8238c529-994a-4bd7-a8bc-525be31184f6">

## 트레이너가 회원이 쓴 차트를 수정하려 할 시

<img width="1439" alt="스크린샷 2024-12-10 오후 7 47 21" src="https://github.com/user-attachments/assets/fb0bd4a6-6761-4a8a-8a54-03e29187ff7e">


close #58 