### PR TITLE
[Feat] 클로바 장문 요약 API 설계 및 조회 API 설계

### DIFF
--- a/src/main/java/com/phu/backend/controller/clova/ClovaController.java
+++ b/src/main/java/com/phu/backend/controller/clova/ClovaController.java
@@ -1,13 +1,17 @@
 package com.phu.backend.controller.clova;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.phu.backend.dto.clova.reqeust.ClovaMessage;
 import com.phu.backend.dto.clova.response.ClovaSpeechResponseList;
+import com.phu.backend.dto.summarization.response.SummarizationResponse;
 import com.phu.backend.service.clova.ClovaService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,9 +25,15 @@ public class ClovaController {
         return ResponseEntity.ok().body(clovaService.clovaSpeech(fileId, memberId));
     }
 
-    @PostMapping("pt/clova/test")
-    @Operation(summary = "챗봇 테스팅", description = "테스트")
-    public ResponseEntity<?> test(@RequestBody ClovaMessage request) throws JsonProcessingException {
-        return ResponseEntity.ok(clovaService.test(request));
+    @GetMapping("pt/clova/summation/{voice-text-id}")
+    @Operation(summary = "장문요약", description = "분석한 텍스트를 요약해준다.")
+    public ResponseEntity<SummarizationResponse> summationTextFile(@PathVariable(name = "voice-text-id")UUID textId) throws JsonProcessingException {
+        return ResponseEntity.ok(clovaService.summationTextFile(textId));
+    }
+
+    @GetMapping("pt/clova/summation/get/{summarization-id}")
+    @Operation(summary = "요약된 텍스트 정보 조회", description = "요약된 텍스트 정보를 조회한다.")
+    public ResponseEntity<SummarizationResponse> getSummarization(@PathVariable(name = "summarization-id") Long summarizationId) {
+        return ResponseEntity.ok(clovaService.getSummarization(summarizationId));
     }
 }

--- a/src/main/java/com/phu/backend/domain/summarization/Summarization.java
+++ b/src/main/java/com/phu/backend/domain/summarization/Summarization.java
@@ -1,0 +1,37 @@
+package com.phu.backend.domain.summarization;
+
+import com.phu.backend.domain.member.Member;
+import com.phu.backend.global.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Summarization extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "summarization_id")
+    private Long id;
+    @Lob
+    @Column(name = "summarization_texts", columnDefinition = "LONGTEXT")
+    private String summarizationTexts;
+    private UUID voiceTextId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member trainer;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @Builder
+    public Summarization(String summarizationTexts, UUID voiceTextId, Member trainer, Member member) {
+        this.summarizationTexts = summarizationTexts;
+        this.voiceTextId = voiceTextId;
+        this.trainer = trainer;
+        this.member = member;
+    }
+}

--- a/src/main/java/com/phu/backend/dto/summarization/response/SummarizationResponse.java
+++ b/src/main/java/com/phu/backend/dto/summarization/response/SummarizationResponse.java
@@ -1,0 +1,29 @@
+package com.phu.backend.dto.summarization.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@NoArgsConstructor
+@Getter
+public class SummarizationResponse {
+    private Long summarizationId;
+    private Long trainerId;
+    private Long memberId;
+    private UUID voiceListId;
+    private String texts;
+    private LocalDateTime createAt;
+
+    @Builder
+    public SummarizationResponse(Long summarizationId, Long trainerId, Long memberId, UUID voiceListId, String texts, LocalDateTime createAt) {
+        this.summarizationId = summarizationId;
+        this.trainerId = trainerId;
+        this.memberId = memberId;
+        this.voiceListId = voiceListId;
+        this.texts = texts;
+        this.createAt = createAt;
+    }
+}

--- a/src/main/java/com/phu/backend/exception/summarization/NotFoundSummarizationException.java
+++ b/src/main/java/com/phu/backend/exception/summarization/NotFoundSummarizationException.java
@@ -1,0 +1,15 @@
+package com.phu.backend.exception.summarization;
+
+import com.phu.backend.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class NotFoundSummarizationException extends GlobalException {
+    public static final String MESSAGE = "해당 회원에 대한 요약본을 찾을 수 없습니다.";
+    @Override
+    public String getStatusCode() {
+        return "SU001";
+    }
+    public NotFoundSummarizationException() {
+        super(MESSAGE, HttpStatus.NOT_ACCEPTABLE);
+    }
+}

--- a/src/main/java/com/phu/backend/repository/summarization/SummarizationRepository.java
+++ b/src/main/java/com/phu/backend/repository/summarization/SummarizationRepository.java
@@ -1,0 +1,7 @@
+package com.phu.backend.repository.summarization;
+
+import com.phu.backend.domain.summarization.Summarization;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SummarizationRepository extends JpaRepository<Summarization, Long> {
+}


### PR DESCRIPTION
# 명세

- 파라미터 : 텍스트 추출한 도메인의 id값 (UUID)

<img width="1209" alt="스크린샷 2025-01-05 오후 7 21 29" src="https://github.com/user-attachments/assets/d21c9221-8881-4900-a628-d18f1720b669" />

<br>

# 응답

해당 정보는 Summarization 도메인 내부에 저장 및 관리됨

<img width="1216" alt="스크린샷 2025-01-05 오후 7 22 05" src="https://github.com/user-attachments/assets/1f008aae-5804-48e7-a9d4-6d2b12b62922" />

<br>

#조회 요청 예시

- 파라미터 : 요약된 도메인의 id

<img width="1243" alt="스크린샷 2025-01-05 오후 7 23 09" src="https://github.com/user-attachments/assets/db788f7e-9491-4f11-bb52-849cc56355eb" />


# 응답

<img width="1254" alt="스크린샷 2025-01-05 오후 7 24 10" src="https://github.com/user-attachments/assets/6425259d-e26a-41d3-9046-46d2b23fa57c" />

close #66 

